### PR TITLE
Now PDFDocument could be initialized from NSData

### DIFF
--- a/Pod/Classes/Renderer/PDFPageContent.swift
+++ b/Pod/Classes/Renderer/PDFPageContent.swift
@@ -27,12 +27,12 @@ class PDFPageContent: UIView {
     }
     
     //MARK: - Init
-    init(url: URL, page:Int, password:String?) {
         
         var viewRect:CGRect = CGRect.zero
         
-        self.pdfDocRef = try! CGPDFDocument.create(url, password: password)
         
+    init(pdfDocument: PDFDocument, page: Int, password: String?) {
+        self.pdfDocRef = pdfDocument.documentRef!
         /// Limit the page
         let pages = self.pdfDocRef.numberOfPages
         var page = page
@@ -96,7 +96,7 @@ class PDFPageContent: UIView {
     
     convenience init(document: PDFDocument, page:Int) {
         
-        self.init(url: document.fileUrl as URL, page:page, password:document.password)
+        self.init(pdfDocument: document, page:page, password:document.password)
     }
     
     required init?(coder aDecoder: NSCoder) {

--- a/Pod/Classes/Renderer/PDFRenderer.swift
+++ b/Pod/Classes/Renderer/PDFRenderer.swift
@@ -25,7 +25,7 @@ open class PDFRenderController {
     open func renderOntoPDF() -> URL {
         let documentRef = document.documentRef
         let pages = document.pageCount
-        let title = document.fileUrl.lastPathComponent
+        let title = document.fileUrl?.lastPathComponent ?? "annotated.pdf"
         let tempPath = NSTemporaryDirectory() + title
         
         UIGraphicsBeginPDFContextToFile(tempPath, CGRect.zero, nil)

--- a/Pod/Classes/Renderer/PDFSnapshotCache.swift
+++ b/Pod/Classes/Renderer/PDFSnapshotCache.swift
@@ -16,14 +16,14 @@ open class PDFSnapshot {
     
     var state = SnapshotState.new
     var image:UIImage?
-    var path:URL
+    var document: PDFDocument
     var page:Int
     var guid:String
     var size:CGSize
     
-    init(path:URL, page: Int, guid: String, size: CGSize) {
+    init(document: PDFDocument, page: Int, guid: String, size: CGSize) {
+        self.document = document
         self.page = page
-        self.path = path
         self.guid = guid
         self.size = size
     }
@@ -47,8 +47,8 @@ open class PDFQueue {
     func fetchPage(_ document: PDFDocument, page: Int, size: CGSize, completion:((PDFSnapshot) -> Void)?) {
         
         let guid = "\(document.guid)_\(page)"
-        let thumbnail = PDFSnapshot(path: document.fileUrl as URL, page: page, guid: guid, size: size)
         
+        let thumbnail = PDFSnapshot(document: document, page: page, guid: guid, size: size)
         if let image = PDFSnapshotCache.sharedCache.objectForKey(guid) {
             thumbnail.image = image
             DispatchQueue.main.async{
@@ -109,8 +109,8 @@ class PDFSnapshotRenderer: Operation {
     
     func renderPDF(_ size: CGSize) -> UIImage? {
         
-        guard let documentRef = CGPDFDocument((self.snapshot.path as CFURL)),
-            let page = documentRef.page(at: self.snapshot.page) else { return nil }
+        let documentRef = self.snapshot.document.documentRef
+        guard let page = documentRef?.page(at: self.snapshot.page) else { return nil }
         
         var pageRect = page.getBoxRect(.mediaBox)
         let scale = min(size.width / pageRect.size.width, size.height / pageRect.size.height)


### PR DESCRIPTION
There are some cases, when you haven't stored PDF file on disk, so you have not url for it: for example, when you just loaded PDF from network.
I just added constructor to PDFDocument class that allows to work with PDF file via NSData.