### PR TITLE
Update 'hides on tap' to content view

### DIFF
--- a/Pod/Classes/Renderer/PDFPageContentView.swift
+++ b/Pod/Classes/Renderer/PDFPageContentView.swift
@@ -11,6 +11,7 @@ import UIKit
 public protocol PDFPageContentViewDelegate {
     
     func contentView(_ contentView: PDFPageContentView, didSelectAction action: PDFAction)
+    func contentView(_ contentView: PDFPageContentView, tapped recognizer: UITapGestureRecognizer)
 }
 
 open class PDFPageContentView: UIScrollView, UIScrollViewDelegate {
@@ -152,7 +153,10 @@ open class PDFPageContentView: UIScrollView, UIScrollViewDelegate {
     
     open func processSingleTap(_ recognizer: UITapGestureRecognizer) {
         
-        guard let action = self.contentView.processSingleTap(recognizer) else { return }
+        guard let action = self.contentView.processSingleTap(recognizer) else {
+            contentDelegate?.contentView(self, tapped: recognizer)
+            return
+        }
         self.contentDelegate?.contentView(self, didSelectAction: action)
     }
     

--- a/Pod/Classes/Renderer/PDFSinglePageViewer.swift
+++ b/Pod/Classes/Renderer/PDFSinglePageViewer.swift
@@ -13,7 +13,7 @@ public protocol PDFSinglePageViewerDelegate {
     func singlePageViewer(_ collectionView: PDFSinglePageViewer, didDisplayPage page:Int)
     func singlePageViewer(_ collectionView: PDFSinglePageViewer, loadedContent content:PDFPageContentView)
     func singlePageViewer(_ collectionView: PDFSinglePageViewer, selectedAction action:PDFAction)
-    func singlePageTapped(_ collectionView: PDFSinglePageViewer, tapped recognizer: UITapGestureRecognizer)
+    func singlePageViewer(_ collectionView: PDFSinglePageViewer, tapped recognizer: UITapGestureRecognizer)
 }
 
 open class PDFSinglePageViewer: UICollectionView {
@@ -182,7 +182,7 @@ extension PDFSinglePageViewer: PDFPageContentViewDelegate {
     }
     
     public func contentView(_ contentView: PDFPageContentView, tapped recognizer: UITapGestureRecognizer) {
-        singlePageDelegate?.singlePageTapped(self, tapped: recognizer)
+        singlePageDelegate?.singlePageViewer(self, tapped: recognizer)
     }
 }
 

--- a/Pod/Classes/Renderer/PDFSinglePageViewer.swift
+++ b/Pod/Classes/Renderer/PDFSinglePageViewer.swift
@@ -13,6 +13,7 @@ public protocol PDFSinglePageViewerDelegate {
     func singlePageViewer(_ collectionView: PDFSinglePageViewer, didDisplayPage page:Int)
     func singlePageViewer(_ collectionView: PDFSinglePageViewer, loadedContent content:PDFPageContentView)
     func singlePageViewer(_ collectionView: PDFSinglePageViewer, selectedAction action:PDFAction)
+    func singlePageTapped(_ collectionView: PDFSinglePageViewer, tapped recognizer: UITapGestureRecognizer)
 }
 
 open class PDFSinglePageViewer: UICollectionView {
@@ -178,6 +179,10 @@ extension PDFSinglePageViewer: PDFPageContentViewDelegate {
         else if let action = action as? PDFActionGoTo {
             self.displayPage(action.pageIndex, animated: true)
         }
+    }
+    
+    public func contentView(_ contentView: PDFPageContentView, tapped recognizer: UITapGestureRecognizer) {
+        singlePageDelegate?.singlePageTapped(self, tapped: recognizer)
     }
 }
 

--- a/Pod/Classes/Renderer/PDFViewController.swift
+++ b/Pod/Classes/Renderer/PDFViewController.swift
@@ -260,7 +260,7 @@ extension PDFViewController: PDFSinglePageViewerDelegate {
         }
     }
     
-    public func singlePageTapped(_ collectionView: PDFSinglePageViewer, tapped recognizer: UITapGestureRecognizer) {
+    public func singlePageViewer(_ collectionView: PDFSinglePageViewer, tapped recognizer: UITapGestureRecognizer) {
         if hidesBarsOnTap {
             handleTap(recognizer)
         }

--- a/Pod/Classes/Renderer/PDFViewController.swift
+++ b/Pod/Classes/Renderer/PDFViewController.swift
@@ -77,13 +77,6 @@ open class PDFViewController: UIViewController {
         
         
         self.reloadBarButtons()
-        
-        
-        if self.hidesBarsOnTap {
-            let gestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(PDFViewController.handleTap(_:)))
-            gestureRecognizer.cancelsTouchesInView = false
-            self.view.addGestureRecognizer(gestureRecognizer)
-        }
     }
     
     func loadDocument(_ document: PDFDocument) {
@@ -264,6 +257,12 @@ extension PDFViewController: PDFSinglePageViewerDelegate {
         }
         else if let action = action as? PDFActionGoTo {
             self.collectionView.displayPage(action.pageIndex, animated: true)
+        }
+    }
+    
+    public func singlePageTapped(_ collectionView: PDFSinglePageViewer, tapped recognizer: UITapGestureRecognizer) {
+        if hidesBarsOnTap {
+            handleTap(recognizer)
         }
     }
 }


### PR DESCRIPTION
Right now, 'hides on tap' only works when you tap on the bottom part of view not anywhere else, this is because you implemented that on parent view(PDFViewController), not on child view(PDFPageContentView). So tap should not just work on the bottom part but also on content part. And with the current implementation, there is one more issue i.e if you select any page using scrubber it hides the navigation bar and scrubber which is not the correct behaviour, it should only hide when tapped elsewhere not when the intention is to change the page.

This pull request implements hide functionality at content view level which is more user-friendly because it works when typed on anywhere on the view and without overriding any other actions.