### PR TITLE
Fixes #19

### DIFF
--- a/Pod/Classes/Extensions/UIImage.swift
+++ b/Pod/Classes/Extensions/UIImage.swift
@@ -9,7 +9,6 @@
 import UIKit
 
 extension UIImage {
-    
     class func bundledImage(_ named: String) -> UIImage? {
         let image = UIImage(named: named)
         

--- a/Pod/Classes/Form/PDFArray.swift
+++ b/Pod/Classes/Form/PDFArray.swift
@@ -59,7 +59,7 @@ class PDFArray: NSObject, PDFObject {
     }
     
     func pdfObjectAtIndex(_ index: Int) -> AnyObject? {
-        var object:CGPDFObjectRef? = nil
+        var object: CGPDFObjectRef? = nil
         if CGPDFArrayGetObject(arr, index, &object) {
             
             let type = CGPDFObjectGetType(object!)

--- a/Pod/Classes/Form/PDFDictionary.swift
+++ b/Pod/Classes/Form/PDFDictionary.swift
@@ -195,7 +195,7 @@ class PDFDictionary: NSObject, PDFObject {
         return nil
     }
     
-    var getDictionaryObjects:CGPDFDictionaryApplierFunction = { (key, object, info) in
+    var getDictionaryObjects: CGPDFDictionaryApplierFunction = { (key, object, info) in
         let context = info!.assumingMemoryBound(to: PDFObjectParserContext.self).pointee
         context.keys.append(key)
     }

--- a/Pod/Classes/Form/PDFDictionary.swift
+++ b/Pod/Classes/Form/PDFDictionary.swift
@@ -176,7 +176,6 @@ class PDFDictionary: NSObject, PDFObject {
     func pdfObjectForKey(_ key: UnsafePointer<Int8>) -> AnyObject? {
         var object: CGPDFObjectRef? = nil
         if CGPDFDictionaryGetObject(dict, key, &object) {
-            
             let type = CGPDFObjectGetType(object!)
             switch type {
             case CGPDFObjectType.boolean: return booleanFromKey(key) as AnyObject?

--- a/Pod/Classes/Form/PDFFormButtonField.swift
+++ b/Pod/Classes/Form/PDFFormButtonField.swift
@@ -9,7 +9,6 @@
 import UIKit
 
 open class PDFFormButtonField: PDFFormField {
-    
     open var radio = false
     open var noOff = false
     open var pushButton = false

--- a/Pod/Classes/Form/PDFFormField.swift
+++ b/Pod/Classes/Form/PDFFormField.swift
@@ -9,7 +9,6 @@
 import UIKit
 
 protocol PDFFormViewDelegate {
-    
     func formFieldValueChanged(_ widget: PDFFormField)
     func formFieldEntered(_ widget: PDFFormField)
     func formFieldOptionsChanged(_ widget: PDFFormField)

--- a/Pod/Classes/Form/PDFFormPageView.swift
+++ b/Pod/Classes/Form/PDFFormPageView.swift
@@ -42,7 +42,7 @@ open class PDFFormPage:NSObject {
     var page: Int
     var zoomScale: CGFloat = 1.0
     
-    init(page:Int) {
+    init(page: Int) {
         self.page = page
     }
     

--- a/Pod/Classes/Form/PDFFormSignatureField.swift
+++ b/Pod/Classes/Form/PDFFormSignatureField.swift
@@ -273,7 +273,7 @@ class PDFFormFieldSignatureCaptureView: UIView {
     }
     
     // Save the Signature as an UIImage
-    func getSignature(scale:CGFloat = 1) -> UIImage? {
+    func getSignature(scale: CGFloat = 1) -> UIImage? {
         if !containsSignature {
             return nil
         }
@@ -286,7 +286,7 @@ class PDFFormFieldSignatureCaptureView: UIView {
         return signature
     }
     
-    func getSignatureCropped(scale:CGFloat = 1) -> UIImage? {
+    func getSignatureCropped(scale: CGFloat = 1) -> UIImage? {
         guard let fullRender = getSignature(scale:scale) else {
             return nil
         }

--- a/Pod/Classes/Model/PDFAction.swift
+++ b/Pod/Classes/Model/PDFAction.swift
@@ -9,9 +9,7 @@
 import Foundation
 
 open class PDFAction {
-    
     open static func fromPDFDictionary(_ sourceDictionary: CGPDFDictionaryRef, documentReference: CGPDFDocument) -> PDFAction? {
-        
         var action: PDFAction?
         var destinationName: CGPDFStringRef? = nil
         var destinationString: UnsafePointer<Int8>? = nil
@@ -199,7 +197,6 @@ open class PDFAction {
 }
 
 open class PDFActionGoTo: PDFAction {
-    
     var pageIndex: Int
     
     public init(pageIndex: Int) {
@@ -208,7 +205,6 @@ open class PDFActionGoTo: PDFAction {
 }
 
 open class PDFActionURL: PDFAction {
-    
     var url: URL
     
     public init(url: URL) {

--- a/Pod/Classes/Renderer/CGPDFDocument.swift
+++ b/Pod/Classes/Renderer/CGPDFDocument.swift
@@ -17,25 +17,20 @@ public enum CGPDFDocumentError: Error {
 extension CGPDFDocument {
     
     public static func create(_ url: URL, password: String?) throws -> CGPDFDocument {
-        
         guard let docRef = CGPDFDocument((url as CFURL)) else {
             throw CGPDFDocumentError.fileDoesNotExist
         }
         
         if docRef.isEncrypted {
-            
             guard let password = password else {
-                
                 throw CGPDFDocumentError.passwordRequired
             }
             
             if docRef.unlockWithPassword("") == false {
-                
                 docRef.unlockWithPassword((password as NSString).utf8String!)
             }
             
             if docRef.isUnlocked == false {
-                
                 throw CGPDFDocumentError.couldNotUnlock
             }
         }

--- a/Pod/Classes/Renderer/PDFDocument.swift
+++ b/Pod/Classes/Renderer/PDFDocument.swift
@@ -58,12 +58,10 @@ open class PDFDocument: NSObject, NSCoding {
     }
     
     static func unarchiveDocumentForFile(_ filePath: String, password: String?) -> PDFDocument? {
-        
         return nil
     }
     
     public required init?(coder aDecoder: NSCoder) {
-        
         self.guid = aDecoder.decodeObject(forKey: "fileGUID") as! String
         self.currentPage = aDecoder.decodeObject(forKey: "currentPage") as! Int
         self.bookmarks = aDecoder.decodeObject(forKey: "bookmarks") as! NSMutableIndexSet
@@ -76,12 +74,10 @@ open class PDFDocument: NSObject, NSCoding {
     }
     
     public convenience init(filePath: String) throws {
-        
         try self.init(filePath: filePath, password: nil)
     }
     
     public init(filePath: String, password: String?) throws {
-        
         self.guid = PDFDocument.GUID()
         self.password = password
         self.fileUrl = URL(fileURLWithPath: filePath, isDirectory: false)
@@ -95,7 +91,6 @@ open class PDFDocument: NSObject, NSCoding {
     }
     
     public init(fileData: NSData, password: String?) throws {
-        
         self.guid = PDFDocument.GUID()
         self.password = password
         self.fileData = fileData
@@ -184,7 +179,6 @@ open class PDFDocument: NSObject, NSCoding {
     //MARK: - Helper methods
     
     static func GUID() -> String {
-        
         return ProcessInfo.processInfo.globallyUniqueString
     }
     
@@ -193,33 +187,28 @@ open class PDFDocument: NSObject, NSCoding {
     }
     
     open static func applicationPath() -> String {
-        
         let paths = NSSearchPathForDirectoriesInDomains(.documentDirectory, .userDomainMask, true)
         return (paths.first! as NSString).deletingLastPathComponent
     }
     
     open static func applicationSupportPath() -> String {
-        
         let fileManager = FileManager()
         let pathURL = try! fileManager.url(for: .applicationSupportDirectory, in: .userDomainMask, appropriateFor: nil, create: true)
         return pathURL.path
     }
     
     static func archiveFilePathForFileAtPath(_ path: String) -> String {
-        
         let archivePath = PDFDocument.applicationSupportPath()
         let archiveName = "random-name-fix-later.plist"
         return (archivePath as NSString).appendingPathComponent(archiveName)
     }
     
     func archiveWithFileAtPath(_ filePath: String) -> Bool {
-        
         let archiveFilePath = PDFDocument.archiveFilePathForFileAtPath(filePath)
         return NSKeyedArchiver.archiveRootObject(self, toFile: archiveFilePath)
     }
     
     open func save() {
-        
         if let filePath = fileUrl?.path {
             let _ = self.archiveWithFileAtPath(filePath)
         }
@@ -264,7 +253,6 @@ open class PDFDocument: NSObject, NSCoding {
     //    }
     
     open func encode(with aCoder: NSCoder) {
-        
         aCoder.encode(self.guid, forKey: "fileGUID")
         aCoder.encode(self.currentPage, forKey: "currentPage")
         aCoder.encode(self.bookmarks, forKey: "bookmarks")

--- a/Pod/Classes/Renderer/PDFDocument.swift
+++ b/Pod/Classes/Renderer/PDFDocument.swift
@@ -10,7 +10,7 @@ import UIKit
 
 open class PDFDocument: NSObject, NSCoding {
     
-    lazy open var documentRef:CGPDFDocument? = {
+    lazy open var documentRef: CGPDFDocument? = {
         do {
             if let fileUrl = self.fileUrl {
                 return try CGPDFDocument.create(fileUrl, password: self.password)

--- a/Pod/Classes/Renderer/PDFPageContent.swift
+++ b/Pod/Classes/Renderer/PDFPageContent.swift
@@ -91,7 +91,7 @@ class PDFPageContent: UIView {
         buildAnnotationLinksList()
     }
     
-    convenience init(document: PDFDocument, page:Int) {
+    convenience init(document: PDFDocument, page: Int) {
         self.init(pdfDocument: document, page: page, password: document.password)
     }
     
@@ -266,7 +266,7 @@ class PDFDocumentLink: NSObject {
     var rect: CGRect
     var dictionary: CGPDFDictionaryRef
     
-    static func new(_ rect:CGRect, dictionary:CGPDFDictionaryRef) -> PDFDocumentLink {
+    static func new(_ rect: CGRect, dictionary: CGPDFDictionaryRef) -> PDFDocumentLink {
         return PDFDocumentLink(rect: rect, dictionary: dictionary)
     }
     

--- a/Pod/Classes/Renderer/PDFPageContentView.swift
+++ b/Pod/Classes/Renderer/PDFPageContentView.swift
@@ -25,7 +25,7 @@ open class PDFPageContentView: UIScrollView, UIScrollViewDelegate {
     
     let bottomKeyboardPadding: CGFloat = 20.0
     
-    init(frame:CGRect, document: PDFDocument, page:Int) {
+    init(frame: CGRect, document: PDFDocument, page: Int) {
         self.page = page
         contentView = PDFPageContent(document: document, page: page)
         
@@ -210,7 +210,7 @@ open class PDFPageContentView: UIScrollView, UIScrollViewDelegate {
         let keyboardEndFrame = (userInfo[UIKeyboardFrameEndUserInfoKey] as! NSValue).cgRectValue
         let convertedKeyboardEndFrame = self.convert(keyboardEndFrame, from: self.window)
         
-        let height:CGFloat
+        let height: CGFloat
         if convertedKeyboardEndFrame.height > 0 && show {
             height = convertedKeyboardEndFrame.height + bottomKeyboardPadding
         } else {
@@ -222,7 +222,7 @@ open class PDFPageContentView: UIScrollView, UIScrollViewDelegate {
     
     
     //MARK: - Helper methods
-    static func zoomScaleThatFits(_ target: CGSize, source:CGSize) -> CGFloat {
+    static func zoomScaleThatFits(_ target: CGSize, source: CGSize) -> CGFloat {
         let widthScale = target.width / source.width
         let heightScale = target.height / source.height
         return (widthScale < heightScale) ? widthScale : heightScale

--- a/Pod/Classes/Renderer/PDFPageContentView.swift
+++ b/Pod/Classes/Renderer/PDFPageContentView.swift
@@ -167,7 +167,6 @@ open class PDFPageContentView: UIScrollView, UIScrollViewDelegate {
     }
     
     open func zoomDecrement() {
-        
         var zoomScale = self.zoomScale
         
         if zoomScale < minimumZoomScale {

--- a/Pod/Classes/Renderer/PDFPageScrubber.swift
+++ b/Pod/Classes/Renderer/PDFPageScrubber.swift
@@ -9,7 +9,7 @@
 import UIKit
 
 public protocol PDFPageScrubberDelegate {
-    func scrubber(_ scrubber:PDFPageScrubber, selectedPage:Int)
+    func scrubber(_ scrubber: PDFPageScrubber, selectedPage: Int)
 }
 
 open class PDFPageScrubber: UIToolbar {

--- a/Pod/Classes/Renderer/PDFRenderer.swift
+++ b/Pod/Classes/Renderer/PDFRenderer.swift
@@ -52,7 +52,6 @@ open class PDFRenderController {
     }
     
     open func save(_ url: URL) -> Bool {
-        
         let tempUrl = self.renderOntoPDF()
         let fileManger = FileManager.default
         do {

--- a/Pod/Classes/Renderer/PDFSinglePageViewer.swift
+++ b/Pod/Classes/Renderer/PDFSinglePageViewer.swift
@@ -16,7 +16,6 @@ public protocol PDFSinglePageViewerDelegate {
 }
 
 open class PDFSinglePageViewer: UICollectionView {
-    
     open var singlePageDelegate: PDFSinglePageViewerDelegate?
     
     open var document: PDFDocument?

--- a/Pod/Classes/Renderer/PDFSinglePageViewer.swift
+++ b/Pod/Classes/Renderer/PDFSinglePageViewer.swift
@@ -21,29 +21,26 @@ open class PDFSinglePageViewer: UICollectionView {
     open var document: PDFDocument?
     fileprivate var bookmarkedPages: [String]?
     
-    public init(frame: CGRect, document: PDFDocument) {
+    private static var flowLayout: UICollectionViewFlowLayout {
         let layout = UICollectionViewFlowLayout()
         layout.scrollDirection = .horizontal
         layout.sectionInset = UIEdgeInsets.zero
         layout.minimumLineSpacing = 0.0
         layout.minimumInteritemSpacing = 0.0
-        
+        return layout
+    }
+    
+    public init(frame: CGRect, document: PDFDocument) {
         self.document = document
         
-        super.init(frame: frame, collectionViewLayout: layout)
+        super.init(frame: frame, collectionViewLayout: PDFSinglePageViewer.flowLayout)
         
         setupCollectionView()
     }
     
     required public init?(coder aDecoder: NSCoder) {
-        let layout = UICollectionViewFlowLayout()
-        layout.scrollDirection = .horizontal
-        layout.sectionInset = UIEdgeInsets.zero
-        layout.minimumLineSpacing = 0.0
-        layout.minimumInteritemSpacing = 0.0
-        
         super.init(coder: aDecoder)
-        collectionViewLayout = layout
+        collectionViewLayout = PDFSinglePageViewer.flowLayout
         
         setupCollectionView()
     }

--- a/Pod/Classes/Renderer/PDFSinglePageViewer.swift
+++ b/Pod/Classes/Renderer/PDFSinglePageViewer.swift
@@ -9,7 +9,6 @@
 import UIKit
 
 public protocol PDFSinglePageViewerDelegate {
-    
     func singlePageViewer(_ collectionView: PDFSinglePageViewer, didDisplayPage page:Int)
     func singlePageViewer(_ collectionView: PDFSinglePageViewer, loadedContent content:PDFPageContentView)
     func singlePageViewer(_ collectionView: PDFSinglePageViewer, selectedAction action:PDFAction)
@@ -152,8 +151,8 @@ extension PDFSinglePageViewer: UIScrollViewDelegate {
         didDisplayPage(scrollView)
     }
     
-    func didDisplayPage(_ scrollView: UIScrollView) {
         let page: Int = Int((scrollView.contentOffset.x + scrollView.frame.size.width) / scrollView.frame.size.width)
+    private func didDisplayPage(_ scrollView: UIScrollView) {
         singlePageDelegate?.singlePageViewer(self, didDisplayPage: page)
     }
 }

--- a/Pod/Classes/Renderer/PDFSinglePageViewer.swift
+++ b/Pod/Classes/Renderer/PDFSinglePageViewer.swift
@@ -9,9 +9,9 @@
 import UIKit
 
 public protocol PDFSinglePageViewerDelegate {
-    func singlePageViewer(_ collectionView: PDFSinglePageViewer, didDisplayPage page:Int)
-    func singlePageViewer(_ collectionView: PDFSinglePageViewer, loadedContent content:PDFPageContentView)
-    func singlePageViewer(_ collectionView: PDFSinglePageViewer, selectedAction action:PDFAction)
+    func singlePageViewer(_ collectionView: PDFSinglePageViewer, didDisplayPage page: Int)
+    func singlePageViewer(_ collectionView: PDFSinglePageViewer, loadedContent content: PDFPageContentView)
+    func singlePageViewer(_ collectionView: PDFSinglePageViewer, selectedAction action: PDFAction)
     func singlePageViewer(_ collectionView: PDFSinglePageViewer, tapped recognizer: UITapGestureRecognizer)
 }
 

--- a/Pod/Classes/Renderer/PDFSinglePageViewer.swift
+++ b/Pod/Classes/Renderer/PDFSinglePageViewer.swift
@@ -151,8 +151,8 @@ extension PDFSinglePageViewer: UIScrollViewDelegate {
         didDisplayPage(scrollView)
     }
     
-        let page: Int = Int((scrollView.contentOffset.x + scrollView.frame.size.width) / scrollView.frame.size.width)
     private func didDisplayPage(_ scrollView: UIScrollView) {
+        let page = Int((scrollView.contentOffset.x + scrollView.frame.size.width) / scrollView.frame.size.width)
         singlePageDelegate?.singlePageViewer(self, didDisplayPage: page)
     }
 }

--- a/Pod/Classes/Renderer/PDFSinglePageViewer.swift
+++ b/Pod/Classes/Renderer/PDFSinglePageViewer.swift
@@ -154,6 +154,13 @@ extension PDFSinglePageViewer: UIScrollViewDelegate {
     private func didDisplayPage(_ scrollView: UIScrollView) {
         let page = Int((scrollView.contentOffset.x + scrollView.frame.size.width) / scrollView.frame.size.width)
         singlePageDelegate?.singlePageViewer(self, didDisplayPage: page)
+        
+        let indexPath = IndexPath(row: page - 1, section: 0)
+        if let cell = cellForItem(at: indexPath) as? PDFSinglePageCell {
+            if let pageContentView = cell.pageContentView {
+                singlePageDelegate?.singlePageViewer(self, loadedContent: pageContentView)
+            }
+        }
     }
 }
 

--- a/Pod/Classes/Renderer/PDFSnapshotCache.swift
+++ b/Pod/Classes/Renderer/PDFSnapshotCache.swift
@@ -147,7 +147,7 @@ class PDFSnapshotCache {
     }
     
     func setObject(_ image: UIImage, key: String) {
-        let bytes:Int = Int(image.size.width * image.size.height * 4.0)
+        let bytes = Int(image.size.width * image.size.height * 4.0)
         cache.setObject(image, forKey: (key as NSString), cost: bytes)
     }
     

--- a/Pod/Classes/Renderer/PDFViewController.swift
+++ b/Pod/Classes/Renderer/PDFViewController.swift
@@ -77,11 +77,6 @@ open class PDFViewController: UIViewController {
         reloadBarButtons()
     }
     
-    func loadDocument(_ document: PDFDocument) {
-        collectionView = PDFSinglePageViewer(frame: view.bounds, document: document)
-        collectionView.translatesAutoresizingMaskIntoConstraints = false
-    }
-    
     open override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
         

--- a/README.md
+++ b/README.md
@@ -63,9 +63,9 @@ collectionView.singlePageDelegate = self
 Its delegate methods are implemented as follows:
 
 ```swift
-func singlePageViewer(collectionView: PDFSinglePageViewer, didDisplayPage page:Int)
-func singlePageViewer(collectionView: PDFSinglePageViewer, loadedContent content:PDFPageContentView)
-func singlePageViewer(collectionView: PDFSinglePageViewer, selectedAction action:PDFAction)
+func singlePageViewer(collectionView: PDFSinglePageViewer, didDisplayPage page: Int)
+func singlePageViewer(collectionView: PDFSinglePageViewer, loadedContent content: PDFPageContentView)
+func singlePageViewer(collectionView: PDFSinglePageViewer, selectedAction action: PDFAction)
 ```
 
 
@@ -106,7 +106,6 @@ To create a new annotation type, you must extend the following protocol:
 
 ```swift
 protocol PDFAnnotation {
-
     func mutableView() -> UIView
     func touchStarted(touch: UITouch, point:CGPoint)
     func touchMoved(touch:UITouch, point:CGPoint)


### PR DESCRIPTION
Bug is caused because `singlePageViewer(_ collectionView: PDFSinglePageViewer, loadedContent content: PDFPageContentView)` does not get called (which updates the `currentPage` and `pageView`) whenever scrolling occurs but no change to the page was made. Now makes sure this is called whenever scrolling occurs