### PR TITLE
Add ability to specify scroll direction

### DIFF
--- a/Pod/Classes/Annotations/PDFAnnotation.swift
+++ b/Pod/Classes/Annotations/PDFAnnotation.swift
@@ -9,6 +9,7 @@
 import UIKit
 
 protocol PDFAnnotation {
+    var page: Int? { get set }
     func mutableView() -> UIView
     func touchStarted(_ touch: UITouch, point: CGPoint)
     func touchMoved(_ touch: UITouch, point: CGPoint)

--- a/Pod/Classes/Annotations/PDFAnnotationController.swift
+++ b/Pod/Classes/Annotations/PDFAnnotationController.swift
@@ -87,7 +87,7 @@ open class PDFAnnotationController: UIViewController {
     open func showAnnotations(_ contentView: PDFPageContentView) {
         currentPage = contentView
         
-        for annot in annotations.annotationsForPage(contentView.page) {
+        for annot in annotations.annotations(page: contentView.page) {
             pageView?.addSubview(annot.mutableView())
         }
     }
@@ -116,9 +116,8 @@ open class PDFAnnotationController: UIViewController {
     
     open func finishAnnotation() {
         guard let annotation = currentAnnotation else { return }
-        guard let currentPage = currentPage else { return }
         
-        annotations.add(annotation, page: currentPage.page)
+        annotations.add(annotation: annotation)
         
         annotationType = .none
         currentAnnotation = nil
@@ -167,7 +166,7 @@ open class PDFAnnotationController: UIViewController {
     func undo() {
         clear()
         guard let currentPage = currentPage else { return }
-        let _ = annotations.undo(currentPage.page)
+        let _ = annotations.undo()
         showAnnotations(currentPage)
     }
     
@@ -206,6 +205,6 @@ open class PDFAnnotationController: UIViewController {
 
 extension PDFAnnotationController: PDFRenderer {
     public func render(_ page: Int, context: CGContext, bounds: CGRect) {
-        annotations.get(page)?.renderInContext(context, size: bounds)
+        annotations.renderInContext(context, size: bounds, page: page)
     }
 }

--- a/Pod/Classes/Annotations/PDFAnnotationController.swift
+++ b/Pod/Classes/Annotations/PDFAnnotationController.swift
@@ -20,7 +20,6 @@ open class PDFAnnotationController: UIViewController {
     var annotations = PDFAnnotationStore()
     var currentPage: PDFPageContentView?
     var pageView: PDFPageContent?
-    var lastPoint: CGPoint?
     var annotationType: PDFAnnotationType = .none
     
     var currentAnnotation: PDFAnnotation?
@@ -180,8 +179,6 @@ open class PDFAnnotationController: UIViewController {
         if let annotation = currentAnnotation {
             annotation.touchStarted(touch, point: point)
         }
-        
-        lastPoint = point
     }
     
     open override func touchesMoved(_ touches: Set<UITouch>, with event: UIEvent?) {
@@ -191,8 +188,6 @@ open class PDFAnnotationController: UIViewController {
         if let annotation = currentAnnotation {
             annotation.touchMoved(touch, point: point)
         }
-        
-        lastPoint = point
     }
     
     open override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?) {
@@ -202,8 +197,6 @@ open class PDFAnnotationController: UIViewController {
         if let annotation = currentAnnotation {
             annotation.touchEnded(touch, point: point)
         }
-        
-        lastPoint = point
     }
 }
 

--- a/Pod/Classes/Annotations/PDFAnnotationController.swift
+++ b/Pod/Classes/Annotations/PDFAnnotationController.swift
@@ -19,7 +19,11 @@ open class PDFAnnotationController: UIViewController {
     var document: PDFDocument!
     var annotations = PDFAnnotationStore()
     var currentPage: PDFPageContentView?
-    var pageView: PDFPageContent?
+    
+    var pageView: PDFPageContent? {
+        return currentPage?.contentView
+    }
+    
     var annotationType: PDFAnnotationType = .none
     
     var currentAnnotation: PDFAnnotation?
@@ -75,12 +79,8 @@ open class PDFAnnotationController: UIViewController {
     //MARK: - Annotation handling
     open func showAnnotations(_ contentView: PDFPageContentView) {
         currentPage = contentView
-        let page = contentView.page
         
-        pageView = contentView.contentView
-        
-        let annotations = self.annotations.annotationsForPage(page)
-        for annot in annotations {
+        for annot in annotations.annotationsForPage(contentView.page) {
             pageView?.addSubview(annot.mutableView())
         }
     }

--- a/Pod/Classes/Annotations/PDFAnnotationController.swift
+++ b/Pod/Classes/Annotations/PDFAnnotationController.swift
@@ -181,10 +181,11 @@ open class PDFAnnotationController: UIViewController {
     //MARK: - Touches methods to pass to annotation
     open override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
         guard let touch = touches.first else { return }
+        
         let page = annotationDelegate?.annotationWillStart(touch: touch)
+        currentAnnotation?.page = page
         
         let point = touch.location(in: pageView)
-        
         currentAnnotation?.touchStarted(touch, point: point)
     }
     

--- a/Pod/Classes/Annotations/PDFAnnotationController.swift
+++ b/Pod/Classes/Annotations/PDFAnnotationController.swift
@@ -15,6 +15,10 @@ public enum PDFAnnotationType {
     case highlighter
 }
 
+public protocol PDFAnnotationControllerProtocol {
+    func annotationWillStart(touch: UITouch) -> Int?
+}
+
 open class PDFAnnotationController: UIViewController {
     var document: PDFDocument!
     var annotations = PDFAnnotationStore()
@@ -25,6 +29,8 @@ open class PDFAnnotationController: UIViewController {
     }
     
     var annotationType: PDFAnnotationType = .none
+    
+    var annotationDelegate: PDFAnnotationControllerProtocol?
     
     var currentAnnotation: PDFAnnotation?
     
@@ -58,8 +64,9 @@ open class PDFAnnotationController: UIViewController {
     )
     
     //MARK: - Init
-    public init(document: PDFDocument) {
+    public init(document: PDFDocument, delegate: PDFAnnotationControllerProtocol) {
         self.document = document
+        self.annotationDelegate = delegate
         
         super.init(nibName: nil, bundle: nil)
         
@@ -174,6 +181,8 @@ open class PDFAnnotationController: UIViewController {
     //MARK: - Touches methods to pass to annotation
     open override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
         guard let touch = touches.first else { return }
+        let page = annotationDelegate?.annotationWillStart(touch: touch)
+        
         let point = touch.location(in: pageView)
         
         currentAnnotation?.touchStarted(touch, point: point)

--- a/Pod/Classes/Annotations/PDFAnnotationController.swift
+++ b/Pod/Classes/Annotations/PDFAnnotationController.swift
@@ -176,34 +176,26 @@ open class PDFAnnotationController: UIViewController {
         guard let touch = touches.first else { return }
         let point = touch.location(in: pageView)
         
-        if let annotation = currentAnnotation {
-            annotation.touchStarted(touch, point: point)
-        }
+        currentAnnotation?.touchStarted(touch, point: point)
     }
     
     open override func touchesMoved(_ touches: Set<UITouch>, with event: UIEvent?) {
         guard let touch = touches.first else { return }
         let point = touch.location(in: pageView)
         
-        if let annotation = currentAnnotation {
-            annotation.touchMoved(touch, point: point)
-        }
+        currentAnnotation?.touchMoved(touch, point: point)
     }
     
     open override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?) {
         guard let touch = touches.first else { return }
         let point = touch.location(in: pageView)
         
-        if let annotation = currentAnnotation {
-            annotation.touchEnded(touch, point: point)
-        }
+        currentAnnotation?.touchEnded(touch, point: point)
     }
 }
 
 extension PDFAnnotationController: PDFRenderer {
     public func render(_ page: Int, context: CGContext, bounds: CGRect) {
-        if let page = annotations.get(page) {
-            page.renderInContext(context, size: bounds)
-        }
+        annotations.get(page)?.renderInContext(context, size: bounds)
     }
 }

--- a/Pod/Classes/Annotations/PDFAnnotationStore.swift
+++ b/Pod/Classes/Annotations/PDFAnnotationStore.swift
@@ -9,49 +9,23 @@
 import UIKit
 
 open class PDFAnnotationStore {
-    var pages: [Int: PDFAnnotationPage] = [:]
-    
-    func add(_ annotation: PDFAnnotation, page: Int) {
-        if let storePage = pages[page] {
-            storePage.addAnnotation(annotation)
-        } else {
-            let storePage = PDFAnnotationPage()
-            storePage.addAnnotation(annotation)
-            storePage.page = page
-            pages[page] = storePage
-        }
-    }
-    
-    func get(_ page: Int) -> PDFAnnotationPage? {
-        return self.pages[page]
-    }
-    
-    func undo(_ page: Int) -> PDFAnnotation? {
-        guard let storePage = pages[page] else { return nil }
-        return storePage.undo()
-    }
-    
-    func annotationsForPage(_ page: Int) -> [PDFAnnotation] {
-        guard let storePage = pages[page] else { return [] }
-        return storePage.annotations
-    }
-}
-
-open class PDFAnnotationPage {
     var annotations: [PDFAnnotation] = []
-    var page: Int = 0
     
-    func addAnnotation(_ annotation: PDFAnnotation) {
+    func add(annotation: PDFAnnotation) {
         annotations.append(annotation)
-    }
-    
-    func renderInContext(_ context: CGContext, size: CGRect) {
-        for annotation in annotations {
-            annotation.drawInContext(context)
-        }
     }
     
     func undo() -> PDFAnnotation? {
         return annotations.popLast()
+    }
+    
+    func annotations(page: Int) -> [PDFAnnotation] {
+        return annotations.filter({ $0.page == page })
+    }
+    
+    func renderInContext(_ context: CGContext, size: CGRect, page: Int) {
+        for annotation in annotations(page: page) {
+            annotation.drawInContext(context)
+        }
     }
 }

--- a/Pod/Classes/Annotations/PDFPathAnnotation.swift
+++ b/Pod/Classes/Annotations/PDFPathAnnotation.swift
@@ -9,6 +9,8 @@
 import UIKit
 
 class PDFPathAnnotation {
+    var page: Int?
+    
     var path: UIBezierPath = UIBezierPath()
     var color: UIColor = UIColor.black {
         didSet {

--- a/Pod/Classes/Annotations/PDFTextAnnotation.swift
+++ b/Pod/Classes/Annotations/PDFTextAnnotation.swift
@@ -9,6 +9,8 @@
 import UIKit
 
 class PDFTextAnnotation: NSObject {
+    var page: Int?
+    
     var text = "" {
         didSet {
             textView.text = text

--- a/Pod/Classes/Form/PDFFormPageView.swift
+++ b/Pod/Classes/Form/PDFFormPageView.swift
@@ -37,7 +37,7 @@ func ==(lhs: PDFFormFlag, rhs: PDFFormFlag) -> Bool {
     return lhs.rawValue == rhs.rawValue
 }
 
-open class PDFFormPage:NSObject {
+open class PDFFormPage: NSObject {
     var fields: [PDFFormFieldObject] = []
     var page: Int
     var zoomScale: CGFloat = 1.0

--- a/Pod/Classes/Renderer/PDFDocument.swift
+++ b/Pod/Classes/Renderer/PDFDocument.swift
@@ -242,16 +242,6 @@ open class PDFDocument: NSObject, NSCoding {
         }
     }
     
-    //    func setCurrentPage(currentPage: Int) {
-    //
-    //        if currentPage < 1 {
-    //            self.currentPage = 1
-    //        }
-    //        else if currentPage > self.pageCount {
-    //            self.currentPage = self.pageCount
-    //        }
-    //    }
-    
     open func encode(with aCoder: NSCoder) {
         aCoder.encode(self.guid, forKey: "fileGUID")
         aCoder.encode(self.currentPage, forKey: "currentPage")

--- a/Pod/Classes/Renderer/PDFPageTileLayer.swift
+++ b/Pod/Classes/Renderer/PDFPageTileLayer.swift
@@ -31,5 +31,9 @@ class PDFPageTileLayer: CATiledLayer {
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
+    
+    override init(layer: Any) {
+        super.init(layer: layer)
+    }
 
 }

--- a/Pod/Classes/Renderer/PDFSinglePageViewer.swift
+++ b/Pod/Classes/Renderer/PDFSinglePageViewer.swift
@@ -128,11 +128,17 @@ extension PDFSinglePageViewer: UICollectionViewDelegate {
 
 extension PDFSinglePageViewer: UICollectionViewDelegateFlowLayout {
     public func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
-        var size = bounds.size
-        //let contentInsetHeight = contentInset.bottom + contentInset.top + 1
-        //size.height -= contentInsetHeight
         
-        return size
+        let flowLayout = collectionViewLayout as! UICollectionViewFlowLayout
+        switch flowLayout.scrollDirection {
+        case .horizontal:
+            var size = bounds.size
+            let contentInsetHeight = contentInset.bottom + contentInset.top + 1
+            size.height -= contentInsetHeight
+            return size
+        case .vertical:
+            return bounds.size
+        }
     }
 }
 

--- a/Pod/Classes/Renderer/PDFSinglePageViewer.swift
+++ b/Pod/Classes/Renderer/PDFSinglePageViewer.swift
@@ -119,10 +119,8 @@ extension PDFSinglePageViewer: UICollectionViewDataSource {
 }
 
 extension PDFSinglePageViewer: UICollectionViewDelegate {
-    
     public func collectionView(_ collectionView: UICollectionView, willDisplay cell: UICollectionViewCell, forItemAt indexPath: IndexPath) {
-        let pdfCell = cell as! PDFSinglePageCell
-        if let pageContentView = pdfCell.pageContentView {
+        if let pdfCell = cell as? PDFSinglePageCell, let pageContentView = pdfCell.pageContentView {
             singlePageDelegate?.singlePageViewer(self, loadedContent: pageContentView)
         }
     }
@@ -131,7 +129,8 @@ extension PDFSinglePageViewer: UICollectionViewDelegate {
 extension PDFSinglePageViewer: UICollectionViewDelegateFlowLayout {
     public func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
         var size = bounds.size
-        size.height -= contentInset.bottom + contentInset.top + 1
+        //let contentInsetHeight = contentInset.bottom + contentInset.top + 1
+        //size.height -= contentInsetHeight
         
         return size
     }
@@ -147,7 +146,14 @@ extension PDFSinglePageViewer: UIScrollViewDelegate {
     }
     
     private func didDisplayPage(_ scrollView: UIScrollView) {
-        let page = Int((scrollView.contentOffset.x + scrollView.frame.size.width) / scrollView.frame.size.width)
+        let flowLayout = collectionViewLayout as! UICollectionViewFlowLayout
+        let page: Int
+        switch flowLayout.scrollDirection {
+        case .horizontal:
+            page = Int((scrollView.contentOffset.x + scrollView.frame.width) / scrollView.frame.width)
+        case .vertical:
+            page = Int((scrollView.contentOffset.y + scrollView.frame.height) / scrollView.frame.height)
+        }
         singlePageDelegate?.singlePageViewer(self, didDisplayPage: page)
         
         let indexPath = IndexPath(row: page - 1, section: 0)
@@ -173,8 +179,9 @@ extension PDFSinglePageViewer: PDFPageContentViewDelegate {
     }
 }
 
-open class PDFSinglePageCell:UICollectionViewCell {
-    fileprivate var _pageContentView: PDFPageContentView?
+open class PDFSinglePageCell: UICollectionViewCell {
+    private var _pageContentView: PDFPageContentView?
+    
     open var pageContentView: PDFPageContentView? {
         get {
             return _pageContentView

--- a/Pod/Classes/Renderer/PDFSinglePageViewer.swift
+++ b/Pod/Classes/Renderer/PDFSinglePageViewer.swift
@@ -19,7 +19,6 @@ open class PDFSinglePageViewer: UICollectionView {
     open var singlePageDelegate: PDFSinglePageViewerDelegate?
     
     open var document: PDFDocument?
-    fileprivate var bookmarkedPages: [String]?
     
     private static var flowLayout: UICollectionViewFlowLayout {
         let layout = UICollectionViewFlowLayout()

--- a/Pod/Classes/Renderer/PDFSinglePageViewer.swift
+++ b/Pod/Classes/Renderer/PDFSinglePageViewer.swift
@@ -105,13 +105,13 @@ extension PDFSinglePageViewer: UICollectionViewDataSource {
     public func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         let cell = self.dequeueReusableCell(withReuseIdentifier: "ContentCell", for: indexPath) as! PDFSinglePageCell
         
-        var contentSize = CGRect.zero
-        contentSize.size = self.collectionView(collectionView, layout: collectionViewLayout, sizeForItemAt: indexPath)
+        let contentSize = self.collectionView(collectionView, layout: collectionViewLayout, sizeForItemAt: indexPath)
+        let contentFrame = CGRect(origin: CGPoint.zero, size: contentSize)
         
         let page = (indexPath as NSIndexPath).row + 1
         
         cell.contentView.autoresizingMask = [.flexibleHeight, .flexibleWidth]
-        cell.pageContentView = PDFPageContentView(frame: contentSize, document: document!, page: page)
+        cell.pageContentView = PDFPageContentView(frame: contentFrame, document: document!, page: page)
         cell.pageContentView?.contentDelegate = self
         
         return cell

--- a/Pod/Classes/Renderer/PDFViewController.swift
+++ b/Pod/Classes/Renderer/PDFViewController.swift
@@ -24,20 +24,11 @@ open class PDFViewController: UIViewController {
     
     var document: PDFDocument!
     
-    lazy var collectionView: PDFSinglePageViewer = {
-        var collectionView = PDFSinglePageViewer(frame: self.view.bounds, document: self.document)
-        collectionView.translatesAutoresizingMaskIntoConstraints = false
-        collectionView.singlePageDelegate = self
-        return collectionView
-    }()
+    var collectionView: PDFSinglePageViewer!
     
-    lazy var pageScrubber: PDFPageScrubber = {
-        var pageScrubber = PDFPageScrubber(frame: CGRect(x: 0, y: self.view.frame.size.height - self.bottomLayoutGuide.length, width: self.view.frame.size.width, height: 44.0), document: self.document)
-        pageScrubber.scrubberDelegate = self
-        pageScrubber.translatesAutoresizingMaskIntoConstraints = false
-        pageScrubber.isHidden = !self.showsScrubber
-        return pageScrubber
-    }()
+    var pageScrubber: PDFPageScrubber!
+    
+    public var scrollDirection: UICollectionViewScrollDirection = .horizontal
     
     lazy var formController: PDFFormViewController = PDFFormViewController(document: self.document)
     lazy var annotationController: PDFAnnotationController = PDFAnnotationController(document: self.document)
@@ -56,6 +47,28 @@ open class PDFViewController: UIViewController {
     
     override open func viewDidLoad() {
         super.viewDidLoad()
+        
+        pageScrubber = PDFPageScrubber(frame: CGRect(x: 0, y: view.frame.size.height - bottomLayoutGuide.length, width: view.frame.size.width, height: 44.0), document: document)
+        pageScrubber.scrubberDelegate = self
+        pageScrubber.translatesAutoresizingMaskIntoConstraints = false
+        pageScrubber.isHidden = !showsScrubber
+        
+        collectionView = PDFSinglePageViewer(frame: view.bounds, document: document)
+        collectionView.translatesAutoresizingMaskIntoConstraints = false
+        collectionView.singlePageDelegate = self
+        
+        let flowLayout = collectionView.collectionViewLayout as! UICollectionViewFlowLayout
+        flowLayout.scrollDirection = scrollDirection
+        
+        switch scrollDirection {
+        case .horizontal:
+            collectionView.isPagingEnabled = true
+            pageScrubber.isHidden = showsScrubber
+        case .vertical:
+            collectionView.isPagingEnabled = false
+            pageScrubber.isHidden = true
+        }
+        
         self.setupUI()
         collectionView.reloadItems(at: [IndexPath(row: 0, section: 0)])
     }
@@ -245,7 +258,7 @@ extension PDFViewController: PDFSinglePageViewerDelegate {
 
 
 open class PDFBarButton: UIBarButtonItem {
-    fileprivate var button: UIButton = UIButton(frame: CGRect(x: 0,y: 0,width: 32,height: 32))
+    fileprivate var button = UIButton(frame: CGRect(x: 0, y: 0, width: 32, height: 32))
     fileprivate var toggled = false
     fileprivate lazy var defaultTint = UIColor.blue
     

--- a/Pod/Classes/Renderer/PDFViewController.swift
+++ b/Pod/Classes/Renderer/PDFViewController.swift
@@ -51,7 +51,6 @@ open class PDFViewController: UIViewController {
         pageScrubber = PDFPageScrubber(frame: CGRect(x: 0, y: view.frame.size.height - bottomLayoutGuide.length, width: view.frame.size.width, height: 44.0), document: document)
         pageScrubber.scrubberDelegate = self
         pageScrubber.translatesAutoresizingMaskIntoConstraints = false
-        pageScrubber.isHidden = !showsScrubber
         
         collectionView = PDFSinglePageViewer(frame: view.bounds, document: document)
         collectionView.translatesAutoresizingMaskIntoConstraints = false
@@ -63,7 +62,7 @@ open class PDFViewController: UIViewController {
         switch scrollDirection {
         case .horizontal:
             collectionView.isPagingEnabled = true
-            pageScrubber.isHidden = showsScrubber
+            pageScrubber.isHidden = !showsScrubber
         case .vertical:
             collectionView.isPagingEnabled = false
             pageScrubber.isHidden = true
@@ -218,7 +217,8 @@ open class PDFViewController: UIViewController {
 extension PDFViewController: PDFAnnotationControllerProtocol {
     public func annotationWillStart(touch: UITouch) -> Int? {
         let tapPoint = touch.location(in: collectionView)
-        return collectionView.indexPathForItem(at: tapPoint)?.row
+        guard let pageIndex = collectionView.indexPathForItem(at: tapPoint)?.row else { return nil }
+        return pageIndex + 1
     }
 }
 

--- a/Pod/Classes/Renderer/PDFViewController.swift
+++ b/Pod/Classes/Renderer/PDFViewController.swift
@@ -31,7 +31,7 @@ open class PDFViewController: UIViewController {
     public var scrollDirection: UICollectionViewScrollDirection = .horizontal
     
     lazy var formController: PDFFormViewController = PDFFormViewController(document: self.document)
-    lazy var annotationController: PDFAnnotationController = PDFAnnotationController(document: self.document)
+    lazy var annotationController: PDFAnnotationController = PDFAnnotationController(document: self.document, delegate: self)
     
     fileprivate var showingAnnotations = false
     fileprivate var showingFormFilling = true
@@ -212,6 +212,13 @@ open class PDFViewController: UIViewController {
     
     func dismissModal() {
         dismiss(animated: true, completion: nil)
+    }
+}
+
+extension PDFViewController: PDFAnnotationControllerProtocol {
+    public func annotationWillStart(touch: UITouch) -> Int? {
+        let tapPoint = touch.location(in: collectionView)
+        return collectionView.indexPathForItem(at: tapPoint)?.row
     }
 }
 


### PR DESCRIPTION
`PDFViewController` now has a `scrollDirection` property (`UICollectionViewScrollDirection`) that allows for being able to customize the scrolling direction. When set to vertical, paging and bottom scrubber are disabled; when set to horizontal, controller functions exactly like previous versions.