### PR TITLE
When scroll direction is set to vertical; page displays full width at every orientation

### DIFF
--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -243,11 +243,11 @@
 				EC4678DC63259E1E556B22354639F826 /* PDFPageScrubberTrackControl.swift */,
 				AE1C7B951EC7E6CED0390CF07A023630 /* PDFPageTileLayer.swift */,
 				B7D9346501AFA05A330677D39DB1650F /* PDFRenderer.swift */,
+				14E3AEB01DD6ED3800CC9C60 /* PDFSinglePageCell.swift */,
 				F33BD08506077733D10565FD32AAE01D /* PDFSinglePageViewer.swift */,
 				C9FE943FC9A290F6F65198FF53EF96E6 /* PDFSnapshotCache.swift */,
 				C6C164216F04F2C8E8102F383F660F44 /* PDFThumbnailView.swift */,
 				C998B073AF0AE6121E63EFF482E2E251 /* PDFViewController.swift */,
-				14E3AEB01DD6ED3800CC9C60 /* PDFSinglePageCell.swift */,
 			);
 			path = Renderer;
 			sourceTree = "<group>";

--- a/Pod/Classes/Form/PDFArray.swift
+++ b/Pod/Classes/Form/PDFArray.swift
@@ -153,9 +153,8 @@ internal class PDFArray: PDFObject {
         let count = CGPDFArrayGetCount(arr)
         
         for i in stride(from: 0, to: count, by: 1) {
-            if let obj = pdfObjectAtIndex(i) {
-                temp.append(obj)
-            }
+            guard let obj = pdfObjectAtIndex(i) else { continue }
+            temp.append(obj)
         }
         
         return temp

--- a/Pod/Classes/Form/PDFDictionary.swift
+++ b/Pod/Classes/Form/PDFDictionary.swift
@@ -20,7 +20,20 @@ fileprivate class PDFObjectParserContext {
     }
 }
 
-internal class PDFDictionary: PDFObject {
+func == (lhs: PDFDictionary, rhs: PDFDictionary) -> Bool {
+    let rect1 = lhs.arrayForKey("Rect")?.rect
+    let rect2 = rhs.arrayForKey("Rect")?.rect
+    
+    let keys1 = lhs.allKeys()
+    let keys2 = rhs.allKeys()
+    
+    let t1 = lhs["T"] as? String
+    let t2 = rhs["T"] as? String
+    
+    return rect1 == rect2 && keys1 == keys2 && t1 == t2
+}
+
+internal class PDFDictionary: PDFObject, Equatable {
     var dict: CGPDFDictionaryRef
     
     lazy var attributes: [String:AnyObject] = {
@@ -73,23 +86,6 @@ internal class PDFDictionary: PDFObject {
     
     func allKeys() -> [String] {
         return stringKeys
-    }
-    
-    func isEqual(_ object: Any?) -> Bool {
-        if let object = object as? PDFDictionary {
-            
-            let rect1 = arrayForKey("Rect")?.rect
-            let rect2 = object.arrayForKey("Rect")?.rect
-            
-            let keys1 = allKeys()
-            let keys2 = object.allKeys()
-            
-            let t1 = self["T"] as? String
-            let t2 = object["T"] as? String
-            
-            return rect1 == rect2 && keys1 == keys2 && t1 == t2
-        }
-        return false
     }
     
     fileprivate func booleanFromKey(_ key: UnsafePointer<Int8>) -> Bool? {

--- a/Pod/Classes/Form/PDFDictionary.swift
+++ b/Pod/Classes/Form/PDFDictionary.swift
@@ -43,18 +43,15 @@ internal class PDFDictionary: PDFObject, Equatable {
         
         self.keys = context.keys
         for key in self.keys {
-            if let stringKey = String(validatingUTF8: key) {
-                self.stringKeys.append(stringKey)
-            }
+            guard let stringKey = String(validatingUTF8: key) else { continue }
+            self.stringKeys.append(stringKey)
         }
 
         var attributes: [String:AnyObject] = [:]
         for key in self.keys {
-            if let stringKey = String(validatingUTF8: key) {
-                if let obj = self.pdfObjectForKey(key) {
-                    attributes[stringKey] = obj
-                }
-            }
+            guard let stringKey = String(validatingUTF8: key) else { continue }
+            guard let obj = self.pdfObjectForKey(key) else { continue }
+            attributes[stringKey] = obj
         }
         return attributes
     }()

--- a/Pod/Classes/Form/PDFFormPageView.swift
+++ b/Pod/Classes/Form/PDFFormPageView.swift
@@ -40,7 +40,7 @@ func ==(lhs: PDFFormFlag, rhs: PDFFormFlag) -> Bool {
 open class PDFFormPage: NSObject {
     let page: Int
     var fields: [PDFFormFieldObject] = []
-    var zoomScale: CGFloat = 1.0
+    let zoomScale: CGFloat = 1.0
     
     init(page: Int) {
         self.page = page
@@ -81,9 +81,9 @@ open class PDFFormPageView: UIView {
     var fieldViews: [PDFFormField] = []
     var zoomScale: CGFloat = 1.0
     
-    var cropBox = CGRect.zero
-    var boundingBox = CGRect.zero
-    var baseFrame: CGRect
+    let cropBox: CGRect
+    let boundingBox: CGRect
+    let baseFrame: CGRect
     
     init(frame: CGRect, boundingBox: CGRect, cropBox: CGRect, fields: [PDFFormFieldObject]) {
         self.baseFrame = frame

--- a/Pod/Classes/Form/PDFFormPageView.swift
+++ b/Pod/Classes/Form/PDFFormPageView.swift
@@ -93,11 +93,10 @@ open class PDFFormPageView: UIView {
         super.init(frame: frame)
         
         for field in fields {
-            if let fieldView = field.createFormField() {
-                addSubview(fieldView)
-                adjustFrame(fieldView)
-                fieldViews.append(fieldView)
-            }
+            guard let fieldView = field.createFormField() else { continue }
+            addSubview(fieldView)
+            adjustFrame(fieldView)
+            fieldViews.append(fieldView)
         }
     }
     

--- a/Pod/Classes/Form/PDFFormSignatureField.swift
+++ b/Pod/Classes/Form/PDFFormSignatureField.swift
@@ -208,10 +208,10 @@ class PDFFormFieldSignatureCaptureView: UIView {
         let spacerEnd = UIBarButtonItem(barButtonSystemItem: .fixedSpace, target: self, action: nil)
         spacerEnd.width = 10.0
         
-        let toolbar = UIToolbar(frame: CGRect(x: 0, y: self.frame.height - 44.0, width: self.frame.width, height: 44.0))
+        let toolbar = UIToolbar(frame: CGRect(x: 0, y: frame.height - 44.0, width: frame.width, height: 44.0))
         toolbar.autoresizingMask = [.flexibleWidth, .flexibleTopMargin]
         toolbar.setItems([spacerStart, clearButton, spacer, doneButton, spacerEnd], animated: false)
-        self.addSubview(toolbar)
+        addSubview(toolbar)
     }
     
     // MARK: - Draw

--- a/Pod/Classes/Form/PDFFormViewController.swift
+++ b/Pod/Classes/Form/PDFFormViewController.swift
@@ -40,9 +40,8 @@ open class PDFFormViewController: NSObject {
             }
 
             for field in fields {
-                if let dictField = field as? PDFDictionary {
-                    self.enumerate(dictField)
-                }
+                guard let dictField = field as? PDFDictionary else { continue }
+                self.enumerate(dictField)
             }
 
             if let lastPage = self.lastPage {
@@ -64,13 +63,11 @@ open class PDFFormViewController: NSObject {
         }
         
         for dict in array {
-            if let innerFieldDict = dict as? PDFDictionary {
-                
-                if let type = innerFieldDict["Type"] as? String , type == "Annot" {
-                    createFormField(innerFieldDict)
-                } else {
-                    enumerate(innerFieldDict)
-                }
+            guard let innerFieldDict = dict as? PDFDictionary else { continue }
+            if let type = innerFieldDict["Type"] as? String , type == "Annot" {
+                createFormField(innerFieldDict)
+            } else {
+                enumerate(innerFieldDict)
             }
         }
     }
@@ -92,9 +89,8 @@ open class PDFFormViewController: NSObject {
             if let dict = kid as? PDFDictionary,
                 let annots = dict.arrayForKey("Annots") {
                 for subField in annots {
-                    if let subField = subField as? PDFDictionary, field == subField {
-                        return page
-                    }
+                    guard let subField = subField as? PDFDictionary, field == subField else { continue }
+                    return page
                 }
             }
             page -= 1

--- a/Pod/Classes/Form/PDFFormViewController.swift
+++ b/Pod/Classes/Form/PDFFormViewController.swift
@@ -92,7 +92,7 @@ open class PDFFormViewController: NSObject {
             if let dict = kid as? PDFDictionary,
                 let annots = dict.arrayForKey("Annots") {
                 for subField in annots {
-                    if field.isEqual(subField) {
+                    if let subField = subField as? PDFDictionary, field == subField {
                         return page
                     }
                 }

--- a/Pod/Classes/Renderer/PDFPageContentView.swift
+++ b/Pod/Classes/Renderer/PDFPageContentView.swift
@@ -68,12 +68,12 @@ open class PDFPageContentView: UIScrollView, UIScrollViewDelegate {
         NotificationCenter.default.addObserver(
             self,
             selector: #selector(PDFPageContentView.keyboardWillShowNotification(_:)),
-            name: NSNotification.Name.UIKeyboardWillShow,
+            name: .UIKeyboardWillShow,
             object: nil)
         NotificationCenter.default.addObserver(
             self,
             selector: #selector(PDFPageContentView.keyboardWillHideNotification(_:)),
-            name: NSNotification.Name.UIKeyboardWillHide,
+            name: .UIKeyboardWillHide,
             object: nil
         )
         
@@ -216,7 +216,7 @@ open class PDFPageContentView: UIScrollView, UIScrollViewDelegate {
             height = 0
         }
 
-        self.contentInset = UIEdgeInsetsMake(0, 0, height, 0)
+        contentInset = UIEdgeInsetsMake(0, 0, height, 0)
     }
     
     

--- a/Pod/Classes/Renderer/PDFPageScrubber.swift
+++ b/Pod/Classes/Renderer/PDFPageScrubber.swift
@@ -17,17 +17,17 @@ open class PDFPageScrubber: UIToolbar {
     var scrubber = PDFPageScrubberTrackControl()
     
     var scrubberDelegate: PDFPageScrubberDelegate?
-    var thumbBackgroundColor = UIColor.white.withAlphaComponent(0.7)
+    let thumbBackgroundColor = UIColor.white.withAlphaComponent(0.7)
     
-    var thumbSmallGap: CGFloat = 2.0
-    var thumbSmallWidth: CGFloat = 22.0
-    var thumbSmallHeight: CGFloat = 28.0
-    var thumbLargeWidth: CGFloat = 32.0
-    var thumbLargeHeight: CGFloat = 42.0
+    let thumbSmallGap: CGFloat = 2.0
+    let thumbSmallWidth: CGFloat = 22.0
+    let thumbSmallHeight: CGFloat = 28.0
+    let thumbLargeWidth: CGFloat = 32.0
+    let thumbLargeHeight: CGFloat = 42.0
     
-    var pageNumberWidth: CGFloat = 96.0
-    var pageNumberHeight: CGFloat = 30.0
-    var pageNumberSpace: CGFloat = 20.0
+    let pageNumberWidth: CGFloat = 96.0
+    let pageNumberHeight: CGFloat = 30.0
+    let pageNumberSpace: CGFloat = 20.0
     
     var thumbViews: [Int: PDFThumbnailView] = [:]
     
@@ -49,11 +49,11 @@ open class PDFPageScrubber: UIToolbar {
     }()
     
     lazy var pageNumberView: UIView = {
-        var numberY = 0.0 - (self.pageNumberHeight + self.pageNumberSpace)
-        var numberX = (self.containerView.bounds.size.width - self.pageNumberWidth) / 2.0
-        var numberRect = CGRect(x: numberX, y: numberY, width: self.pageNumberWidth, height: self.pageNumberHeight)
+        let numberY = 0.0 - (self.pageNumberHeight + self.pageNumberSpace)
+        let numberX = (self.containerView.bounds.size.width - self.pageNumberWidth) / 2.0
+        let numberRect = CGRect(x: numberX, y: numberY, width: self.pageNumberWidth, height: self.pageNumberHeight)
         
-        var pageNumberView = UIView(frame: numberRect)
+        let pageNumberView = UIView(frame: numberRect)
         
         pageNumberView.autoresizesSubviews = false
         pageNumberView.isUserInteractionEnabled = false
@@ -67,7 +67,7 @@ open class PDFPageScrubber: UIToolbar {
     lazy var pageNumberLabel: UILabel = {
         let textRect = self.pageNumberView.bounds.insetBy(dx: 4.0, dy: 2.0)
 
-        var pageNumberLabel = UILabel(frame: textRect)
+        let pageNumberLabel = UILabel(frame: textRect)
         
         pageNumberLabel.autoresizesSubviews = false
         pageNumberLabel.autoresizingMask = UIViewAutoresizing()

--- a/Pod/Classes/Renderer/PDFPageScrubberThumb.swift
+++ b/Pod/Classes/Renderer/PDFPageScrubberThumb.swift
@@ -9,8 +9,8 @@
 import UIKit
 
 internal class PDFPageScrubberThumb: PDFThumbnailView {
-    var small = false
-    var color = UIColor.white
+    let small: Bool
+    let color: UIColor
     
     init(frame: CGRect, small: Bool, color: UIColor) {
         self.small = small
@@ -21,6 +21,8 @@ internal class PDFPageScrubberThumb: PDFThumbnailView {
     }
     
     required init?(coder aDecoder: NSCoder) {
+        small = false
+        color = UIColor.white
         super.init(coder: aDecoder)
         setupUI()
     }

--- a/Pod/Classes/Renderer/PDFRenderer.swift
+++ b/Pod/Classes/Renderer/PDFRenderer.swift
@@ -32,18 +32,17 @@ open class PDFRenderController {
             let page = documentRef?.page(at: i)
             let bounds = document.boundsForPDFPage(i)
             
-            if let context = UIGraphicsGetCurrentContext() {
-                UIGraphicsBeginPDFPageWithInfo(bounds, nil)
-                context.translateBy(x: 0, y: bounds.size.height)
-                context.scaleBy(x: 1.0, y: -1.0)
-                context.drawPDFPage (page!)
-                
-                context.scaleBy(x: 1.0, y: -1.0)
-                context.translateBy(x: 0, y: -bounds.size.height)
-                
-                for controller in renderControllers {
-                    controller.render(i, context:context, bounds:bounds)
-                }
+            guard let context = UIGraphicsGetCurrentContext() else { continue }
+            UIGraphicsBeginPDFPageWithInfo(bounds, nil)
+            context.translateBy(x: 0, y: bounds.size.height)
+            context.scaleBy(x: 1.0, y: -1.0)
+            context.drawPDFPage (page!)
+            
+            context.scaleBy(x: 1.0, y: -1.0)
+            context.translateBy(x: 0, y: -bounds.size.height)
+            
+            for controller in renderControllers {
+                controller.render(i, context:context, bounds:bounds)
             }
         }
         UIGraphicsEndPDFContext()

--- a/Pod/Classes/Renderer/PDFSinglePageViewer.swift
+++ b/Pod/Classes/Renderer/PDFSinglePageViewer.swift
@@ -83,7 +83,12 @@ open class PDFSinglePageViewer: UICollectionView {
     open func displayPage(_ page: Int, animated: Bool) {
         let currentPage = indexForPage(page)
         let indexPath = IndexPath(item: currentPage, section: 0)
-        self.scrollToItem(at: indexPath, at: .centeredHorizontally, animated: animated)
+        switch scrollDirection {
+        case .horizontal:
+            scrollToItem(at: indexPath, at: .centeredHorizontally, animated: animated)
+        case .vertical:
+            scrollToItem(at: indexPath, at: .top, animated: animated)
+        }
     }
     
     open func getPageContent(_ page: Int) -> PDFPageContentView? {
@@ -187,7 +192,8 @@ extension PDFSinglePageViewer: UIScrollViewDelegate {
         case .horizontal:
             page = Int((scrollView.contentOffset.x + scrollView.frame.width) / scrollView.frame.width)
         case .vertical:
-            page = Int((scrollView.contentOffset.y + scrollView.frame.height) / scrollView.frame.height)
+            let currentlyShownIndexPath = indexPathsForVisibleItems.first ?? IndexPath(item: 0, section: 0)
+            page = currentlyShownIndexPath.row + 1
         }
         singlePageDelegate?.singlePageViewer(self, didDisplayPage: page)
         

--- a/Pod/Classes/Renderer/PDFSinglePageViewer.swift
+++ b/Pod/Classes/Renderer/PDFSinglePageViewer.swift
@@ -139,7 +139,23 @@ extension PDFSinglePageViewer: UICollectionViewDelegateFlowLayout {
             size.height -= contentInsetHeight
             return size
         case .vertical:
-            return bounds.size
+            let page = indexPath.row + 1
+            let contentViewSize = PDFPageContentView(frame: bounds, document: document!, page: page).contentSize
+            
+            // Find proper aspect ratio so that cell is full width
+            let widthMultiplier: CGFloat
+            let heightMultiplier: CGFloat
+            if contentViewSize.width == bounds.width {
+                widthMultiplier = bounds.height / contentViewSize.height
+                heightMultiplier = 1
+            } else if contentViewSize.height == bounds.height {
+                heightMultiplier = bounds.width / contentViewSize.width
+                widthMultiplier = 1
+            } else {
+                fatalError()
+            }
+            
+            return CGSize(width: bounds.size.width * widthMultiplier, height: bounds.size.height * heightMultiplier)
         }
     }
 }

--- a/Pod/Classes/Renderer/PDFSinglePageViewer.swift
+++ b/Pod/Classes/Renderer/PDFSinglePageViewer.swift
@@ -22,6 +22,11 @@ open class PDFSinglePageViewer: UICollectionView {
     
     open var document: PDFDocument?
     
+    var scrollDirection: UICollectionViewScrollDirection {
+        let flowLayout = collectionViewLayout as! UICollectionViewFlowLayout
+        return flowLayout.scrollDirection
+    }
+    
     private static var flowLayout: UICollectionViewFlowLayout {
         let layout = UICollectionViewFlowLayout()
         layout.scrollDirection = .horizontal
@@ -65,14 +70,14 @@ open class PDFSinglePageViewer: UICollectionView {
     }
     
     open func indexForPage(_ page: Int) -> Int {
-        var currentPage = page - 1
+        let currentPage = page - 1
         if currentPage <= 0 {
-            currentPage = 0
+            return 0
+        } else if let pageCount = document?.pageCount, currentPage > pageCount {
+            return pageCount - 1
+        } else {
+            return currentPage
         }
-        if let document = document, currentPage > document.pageCount {
-            currentPage = document.pageCount - 1
-        }
-        return currentPage
     }
     
     open func displayPage(_ page: Int, animated: Bool) {
@@ -130,9 +135,7 @@ extension PDFSinglePageViewer: UICollectionViewDelegate {
 
 extension PDFSinglePageViewer: UICollectionViewDelegateFlowLayout {
     public func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
-        
-        let flowLayout = collectionViewLayout as! UICollectionViewFlowLayout
-        switch flowLayout.scrollDirection {
+        switch scrollDirection {
         case .horizontal:
             var size = bounds.size
             let contentInsetHeight = contentInset.bottom + contentInset.top + 1
@@ -179,9 +182,8 @@ extension PDFSinglePageViewer: UIScrollViewDelegate {
     }
     
     private func didDisplayPage(_ scrollView: UIScrollView) {
-        let flowLayout = collectionViewLayout as! UICollectionViewFlowLayout
         let page: Int
-        switch flowLayout.scrollDirection {
+        switch scrollDirection {
         case .horizontal:
             page = Int((scrollView.contentOffset.x + scrollView.frame.width) / scrollView.frame.width)
         case .vertical:

--- a/Pod/Classes/Renderer/PDFSinglePageViewer.swift
+++ b/Pod/Classes/Renderer/PDFSinglePageViewer.swift
@@ -110,7 +110,7 @@ extension PDFSinglePageViewer: UICollectionViewDataSource {
         let contentSize = self.collectionView(collectionView, layout: collectionViewLayout, sizeForItemAt: indexPath)
         let contentFrame = CGRect(origin: CGPoint.zero, size: contentSize)
         
-        let page = (indexPath as NSIndexPath).row + 1
+        let page = indexPath.row + 1
         
         cell.contentView.autoresizingMask = [.flexibleHeight, .flexibleWidth]
         cell.pageContentView = PDFPageContentView(frame: contentFrame, document: document!, page: page)

--- a/Pod/Classes/Renderer/PDFViewController.swift
+++ b/Pod/Classes/Renderer/PDFViewController.swift
@@ -28,6 +28,8 @@ open class PDFViewController: UIViewController {
     
     var pageScrubber: PDFPageScrubber!
     
+    var shareFormBarButtonItem: UIBarButtonItem?
+    
     public var scrollDirection: UICollectionViewScrollDirection = .horizontal
     
     lazy var formController: PDFFormViewController = PDFFormViewController(document: self.document)
@@ -131,12 +133,13 @@ open class PDFViewController: UIViewController {
         var buttons: [UIBarButtonItem] = []
         
         if allowsSharing {
-            buttons.append(UIBarButtonItem(
+            let shareFormBarButtonItem = UIBarButtonItem(
                 barButtonSystemItem: .action,
                 target: self,
                 action: #selector(PDFViewController.shareForm)
-                )
             )
+            buttons.append(shareFormBarButtonItem)
+            self.shareFormBarButtonItem = shareFormBarButtonItem
         }
         
         if allowsFormFilling {
@@ -224,8 +227,7 @@ open class PDFViewController: UIViewController {
         if UIDevice.current.userInterfaceIdiom == .pad {
             activityVC.modalPresentationStyle = .popover
             let popController = activityVC.popoverPresentationController
-            popController?.sourceView = self.view
-            popController?.sourceRect = CGRect(x: self.view.frame.width - 34, y: 64, width: 0, height: 0)
+            popController?.barButtonItem = shareFormBarButtonItem
             popController?.permittedArrowDirections = .up
         }
         present(activityVC, animated: true, completion: nil)

--- a/Pod/Classes/Renderer/PDFViewController.swift
+++ b/Pod/Classes/Renderer/PDFViewController.swift
@@ -77,17 +77,17 @@ open class PDFViewController: UIViewController {
         view.addSubview(pageScrubber)
         view.addSubview(annotationController.view)
         
-        self.collectionView.leadingAnchor.constraint(equalTo: self.view.leadingAnchor).isActive = true
-        self.collectionView.trailingAnchor.constraint(equalTo: self.view.trailingAnchor).isActive = true
-        self.collectionView.topAnchor.constraint(equalTo: self.view.topAnchor).isActive = true
-        self.collectionView.bottomAnchor.constraint(equalTo: self.view.bottomAnchor).isActive = true
+        collectionView.leadingAnchor.constraint(equalTo: view.leadingAnchor).isActive = true
+        collectionView.trailingAnchor.constraint(equalTo: view.trailingAnchor).isActive = true
+        collectionView.topAnchor.constraint(equalTo: view.topAnchor).isActive = true
+        collectionView.bottomAnchor.constraint(equalTo: view.bottomAnchor).isActive = true
         
-        self.pageScrubber.bottomAnchor.constraint(equalTo: self.view.bottomAnchor).isActive = true
-        self.pageScrubber.leadingAnchor.constraint(equalTo: self.view.leadingAnchor).isActive = true
-        self.pageScrubber.trailingAnchor.constraint(equalTo: self.view.trailingAnchor).isActive = true
-        self.pageScrubber.heightAnchor.constraint(equalToConstant: 44.0).isActive = true
+        pageScrubber.bottomAnchor.constraint(equalTo: view.bottomAnchor).isActive = true
+        pageScrubber.leadingAnchor.constraint(equalTo: view.leadingAnchor).isActive = true
+        pageScrubber.trailingAnchor.constraint(equalTo: view.trailingAnchor).isActive = true
+        pageScrubber.heightAnchor.constraint(equalToConstant: 44.0).isActive = true
         
-        self.automaticallyAdjustsScrollViewInsets = false
+        automaticallyAdjustsScrollViewInsets = false
         
         pageScrubber.sizeToFit()
         

--- a/Pod/Classes/Renderer/PDFViewController.swift
+++ b/Pod/Classes/Renderer/PDFViewController.swift
@@ -184,7 +184,17 @@ open class PDFViewController: UIViewController {
     
     func hideBars(state: Bool) {
         navigationController?.setNavigationBarHidden(state, animated: true)
-        pageScrubber.isHidden = state
+        
+        switch scrollDirection {
+        case .horizontal:
+            if showsScrubber {
+                pageScrubber.isHidden = state
+            } else {
+                pageScrubber.isHidden = true
+            }
+        case .vertical:
+            pageScrubber.isHidden = true
+        }
     }
     
     func toggleBars() {


### PR DESCRIPTION
When scroll direction is set to vertical, page will always display full width