### PR TITLE
Develop - callbacks and visibility changes

### DIFF
--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -493,8 +493,11 @@
 				LastSwiftUpdateCheck = 0730;
 				LastUpgradeCheck = 0830;
 				TargetAttributes = {
+					9C492BC63E45F8B8D516D6487251ECE8 = {
+						LastSwiftMigration = 0830;
+					};
 					D7C77B95095598F2FFA1E9456D29905E = {
-						LastSwiftMigration = 0820;
+						LastSwiftMigration = 0830;
 					};
 				};
 			};
@@ -625,14 +628,19 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = A4813EE89CCCB14693E9B61A6CD6117F /* UXMPDFKit.xcconfig */;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
 				CONFIGURATION_BUILD_DIR = "$(BUILD_DIR)/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)/UXMPDFKit";
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_NO_COMMON_BLOCKS = YES;
 				INFOPLIST_FILE = "Target Support Files/UXMPDFKit/ResourceBundle-UXMPDFKit-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_NAME = UXMPDFKit;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
+				SWIFT_OBJC_BRIDGING_HEADER = "../../Pod/Classes/Annotations/UXMPDFKit-UXMPDFKit-Bridging-Header.h";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				WRAPPER_EXTENSION = bundle;
 			};
@@ -642,14 +650,18 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = A4813EE89CCCB14693E9B61A6CD6117F /* UXMPDFKit.xcconfig */;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
 				CONFIGURATION_BUILD_DIR = "$(BUILD_DIR)/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)/UXMPDFKit";
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_NO_COMMON_BLOCKS = YES;
 				INFOPLIST_FILE = "Target Support Files/UXMPDFKit/ResourceBundle-UXMPDFKit-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_NAME = UXMPDFKit;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
+				SWIFT_OBJC_BRIDGING_HEADER = "../../Pod/Classes/Annotations/UXMPDFKit-UXMPDFKit-Bridging-Header.h";
+				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				WRAPPER_EXTENSION = bundle;
 			};

--- a/Pod/Classes/Annotations/PDFAnnotationStore.swift
+++ b/Pod/Classes/Annotations/PDFAnnotationStore.swift
@@ -10,54 +10,54 @@ import UIKit
 
 
 public protocol PDFAnnotationStoreDelegate {
-    
+
     func annotationStore(store: PDFAnnotationStore, addedAnnotation: PDFAnnotation)
     func annotationStore(store: PDFAnnotationStore, removedAnnotation: PDFAnnotation)
 }
 
 open class PDFAnnotationStore: NSObject, NSCoding {
-    
+
     var annotations: [PDFAnnotation] = []
     var delegate: PDFAnnotationStoreDelegate?
-    
-    func add(annotation: PDFAnnotation) {
-        annotation.save()
+
+
+    open func add(annotation: PDFAnnotation) {
         annotations.append(annotation)
         self.delegate?.annotationStore(store: self, addedAnnotation: annotation)
     }
-    
+
     func remove(annotation: PDFAnnotation) {
         if let index = annotations.index(where: { $0.uuid == annotation.uuid }), index > -1 {
             self.delegate?.annotationStore(store: self, removedAnnotation: annotation)
             self.annotations.remove(at: index)
         }
     }
-    
+
     func undo() -> PDFAnnotation? {
-        
+
         if let annotation = annotations.popLast() {
             self.delegate?.annotationStore(store: self, removedAnnotation: annotation)
             return annotation
         }
         return nil
     }
-    
+
     func annotations(page: Int) -> [PDFAnnotation] {
         return annotations.filter({ $0.page == page })
     }
-    
+
     func renderInContext(_ context: CGContext, size: CGRect, page: Int) {
         for annotation in annotations(page: page) {
             annotation.drawInContext(context)
         }
     }
-    
+
     override init() { super.init() }
-    
+
     required public init(coder aDecoder: NSCoder) {
         annotations = aDecoder.decodeObject(forKey: "annotations") as! [PDFAnnotation]
     }
-    
+
     public func encode(with aCoder: NSCoder) {
         aCoder.encode(annotations, forKey: "annotations")
     }

--- a/Pod/Classes/Annotations/PDFAnnotationStore.swift
+++ b/Pod/Classes/Annotations/PDFAnnotationStore.swift
@@ -21,7 +21,7 @@ open class PDFAnnotationStore: NSObject, NSCoding {
     var delegate: PDFAnnotationStoreDelegate?
 
 
-    open func add(annotation: PDFAnnotation) {
+    func add(annotation: PDFAnnotation) {
         annotations.append(annotation)
         self.delegate?.annotationStore(store: self, addedAnnotation: annotation)
     }

--- a/Pod/Classes/Renderer/PDFPageContent.swift
+++ b/Pod/Classes/Renderer/PDFPageContent.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-open class PDFPageContent: UIView {
+public class PDFPageContent: UIView {
     
     private let pdfDocRef: CGPDFDocument
     private let pdfPageRef: CGPDFPage?
@@ -23,7 +23,7 @@ open class PDFPageContent: UIView {
     var cropBoxRect: CGRect
     var viewRect: CGRect = CGRect.zero
     
-    override open class var layerClass : AnyClass {
+    override public class var layerClass : AnyClass {
         return PDFPageTileLayer.self
     }
     
@@ -99,7 +99,7 @@ open class PDFPageContent: UIView {
         fatalError("init(coder:) has not been implemented")
     }
     
-    override open func removeFromSuperview() {
+    override public func removeFromSuperview() {
         layer.delegate = nil
         super.removeFromSuperview()
     }

--- a/Pod/Classes/Renderer/PDFPageContent.swift
+++ b/Pod/Classes/Renderer/PDFPageContent.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-internal class PDFPageContent: UIView {
+open class PDFPageContent: UIView {
     
     private let pdfDocRef: CGPDFDocument
     private let pdfPageRef: CGPDFPage?
@@ -23,7 +23,7 @@ internal class PDFPageContent: UIView {
     var cropBoxRect: CGRect
     var viewRect: CGRect = CGRect.zero
     
-    override class var layerClass : AnyClass {
+    override open class var layerClass : AnyClass {
         return PDFPageTileLayer.self
     }
     
@@ -95,11 +95,11 @@ internal class PDFPageContent: UIView {
         self.init(pdfDocument: document, page: page, password: document.password)
     }
     
-    required init?(coder aDecoder: NSCoder) {
+    required public init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
     
-    override func removeFromSuperview() {
+    override open func removeFromSuperview() {
         layer.delegate = nil
         super.removeFromSuperview()
     }
@@ -230,7 +230,7 @@ internal class PDFPageContent: UIView {
     }
     
     //MARK: - CATiledLayer Delegate Methods
-    override func draw(_ layer: CALayer, in ctx: CGContext) {
+    override open func draw(_ layer: CALayer, in ctx: CGContext) {
         guard let pdfPageRef = pdfPageRef else { return }
         ctx.setFillColor(red: 1.0, green: 1.0, blue: 1.0, alpha: 1.0)
         ctx.fill(ctx.boundingBoxOfClipPath)

--- a/Pod/Classes/Renderer/PDFPageContentView.swift
+++ b/Pod/Classes/Renderer/PDFPageContentView.swift
@@ -12,6 +12,7 @@ public protocol PDFPageContentViewDelegate {
     func contentView(_ contentView: PDFPageContentView, didSelect action: PDFAction)
     func contentView(_ contentView: PDFPageContentView, didSelect annotation: PDFAnnotationView)
     func contentView(_ contentView: PDFPageContentView, tapped recognizer: UITapGestureRecognizer)
+    func contentView(_ contentView: PDFPageContentView, doubleTapped recognizer: UITapGestureRecognizer)
 }
 
 open class PDFPageContentView: UIScrollView, UIScrollViewDelegate {
@@ -92,6 +93,16 @@ open class PDFPageContentView: UIScrollView, UIScrollViewDelegate {
         singleTapRecognizer.numberOfTapsRequired = 1
         singleTapRecognizer.cancelsTouchesInView = false
         self.addGestureRecognizer(singleTapRecognizer)
+
+        let doubleTapRecognizer = UITapGestureRecognizer(
+            target: self,
+            action: #selector(PDFPageContentView.processDoubleTap(_:))
+        )
+        doubleTapRecognizer.numberOfTouchesRequired = 1
+        doubleTapRecognizer.numberOfTapsRequired = 2
+        doubleTapRecognizer.cancelsTouchesInView = false
+        singleTapRecognizer.require(toFail: singleTapRecognizer)
+        self.addGestureRecognizer(doubleTapRecognizer)
     }
 
     required public init?(coder aDecoder: NSCoder) {
@@ -150,6 +161,10 @@ open class PDFPageContentView: UIScrollView, UIScrollViewDelegate {
         else {
             contentDelegate?.contentView(self, tapped: recognizer)
         }
+    }
+
+    open func processDoubleTap(_ recognizer: UITapGestureRecognizer) {
+        contentDelegate?.contentView(self, doubleTapped: recognizer)
     }
 
     open override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {

--- a/Pod/Classes/Renderer/PDFPageContentView.swift
+++ b/Pod/Classes/Renderer/PDFPageContentView.swift
@@ -16,12 +16,8 @@ public protocol PDFPageContentViewDelegate {
 }
 
 open class PDFPageContentView: UIScrollView, UIScrollViewDelegate {
-    let contentView: PDFPageContent
+    open let contentView: PDFPageContent
     let containerView: UIView
-
-    open var pdfContentView: UIView {
-        return contentView as UIView
-    }
 
     open var page: Int
     open var contentDelegate: PDFPageContentViewDelegate?

--- a/Pod/Classes/Renderer/PDFPageContentView.swift
+++ b/Pod/Classes/Renderer/PDFPageContentView.swift
@@ -16,7 +16,7 @@ public protocol PDFPageContentViewDelegate {
 }
 
 open class PDFPageContentView: UIScrollView, UIScrollViewDelegate {
-    open let contentView: PDFPageContent
+    public let contentView: PDFPageContent
     let containerView: UIView
 
     open var page: Int

--- a/Pod/Classes/Renderer/PDFPageContentView.swift
+++ b/Pod/Classes/Renderer/PDFPageContentView.swift
@@ -17,28 +17,32 @@ public protocol PDFPageContentViewDelegate {
 open class PDFPageContentView: UIScrollView, UIScrollViewDelegate {
     let contentView: PDFPageContent
     let containerView: UIView
-    
+
+    open var pdfContentView: UIView {
+        return contentView as UIView
+    }
+
     open var page: Int
     open var contentDelegate: PDFPageContentViewDelegate?
     open var viewDidZoom: ((CGFloat) -> Void)?
     fileprivate var PDFPageContentViewContext = 0
     fileprivate var previousScale: CGFloat = 1.0
-    
+
     let bottomKeyboardPadding: CGFloat = 20.0
-    
+
     init(frame: CGRect, document: PDFDocument, page: Int) {
         self.page = page
         contentView = PDFPageContent(document: document, page: page)
-        
+
         containerView = UIView(frame: contentView.bounds)
         containerView.isUserInteractionEnabled = true
         containerView.contentMode = .redraw
         containerView.backgroundColor = UIColor.white
         containerView.autoresizesSubviews = true
         containerView.autoresizingMask = [.flexibleHeight, .flexibleWidth]
-        
+
         super.init(frame: frame)
-        
+
         scrollsToTop = false
         delaysContentTouches = false
         showsVerticalScrollIndicator = false
@@ -52,22 +56,22 @@ open class PDFPageContentView: UIScrollView, UIScrollViewDelegate {
         delegate = self
         isScrollEnabled = true
         clipsToBounds = true
-        
+
         autoresizingMask = [.flexibleHeight, .flexibleWidth]
-        
+
         contentView.translatesAutoresizingMaskIntoConstraints = false
         contentSize = contentView.bounds.size
-        
+
         containerView.addSubview(contentView)
         addSubview(containerView)
-        
+
         updateMinimumMaximumZoom()
-        
+
         zoomScale = minimumZoomScale
         tag = page
-        
+
         self.addObserver(self, forKeyPath: "frame", options: [.new, .old], context: &PDFPageContentViewContext)
-        
+
         NotificationCenter.default.addObserver(
             self,
             selector: #selector(PDFPageContentView.keyboardWillShowNotification(_:)),
@@ -79,7 +83,7 @@ open class PDFPageContentView: UIScrollView, UIScrollViewDelegate {
             name: .UIKeyboardWillHide,
             object: nil
         )
-        
+
         let singleTapRecognizer = UITapGestureRecognizer(
             target: self,
             action: #selector(PDFPageContentView.processSingleTap(_:))
@@ -93,26 +97,26 @@ open class PDFPageContentView: UIScrollView, UIScrollViewDelegate {
     required public init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
+
     deinit {
         NotificationCenter.default.removeObserver(self, name: .UIKeyboardWillShow, object: nil)
         NotificationCenter.default.removeObserver(self, name: .UIKeyboardWillHide, object: nil)
-        
+
         self.removeObserver(self, forKeyPath: "frame")
     }
-    
+
     override open func layoutSubviews() {
         super.layoutSubviews()
-        
+
         let boundsSize = bounds.size
         var viewFrame = containerView.frame
-        
+
         if viewFrame.size.width < boundsSize.width {
             viewFrame.origin.x = (boundsSize.width - viewFrame.size.width) / 2.0 + contentOffset.x
         } else {
             viewFrame.origin.x = 0.0
         }
-        
+
         if viewFrame.size.height < boundsSize.height {
             viewFrame.origin.y = (boundsSize.height - viewFrame.size.height) / 2.0 + contentOffset.y
         }
@@ -123,19 +127,19 @@ open class PDFPageContentView: UIScrollView, UIScrollViewDelegate {
         containerView.frame = viewFrame
         contentView.frame = containerView.bounds
     }
-    
+
     override open func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey : Any]?, context: UnsafeMutableRawPointer?) {
-        
+
         guard context == &PDFPageContentViewContext,
             let keyPath = keyPath, keyPath == "frame",
             self == (object as? PDFPageContentView) else {
             return
         }
-        
+
         updateMinimumMaximumZoom()
         self.zoomReset()
     }
-    
+
     open func processSingleTap(_ recognizer: UITapGestureRecognizer) {
         if let action = contentView.processSingleTap(recognizer) as? PDFAction {
             contentDelegate?.contentView(self, didSelect: action)
@@ -147,76 +151,76 @@ open class PDFPageContentView: UIScrollView, UIScrollViewDelegate {
             contentDelegate?.contentView(self, tapped: recognizer)
         }
     }
-    
+
     open override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
         let result = super.hitTest(point, with: event)
         self.isScrollEnabled = !(result is ResizableBorderView)
         return result
     }
-    
-    
+
+
     //MARK: - Zoom methods
     open func zoomIncrement() {
         var zoomScale = self.zoomScale
-        
+
         if zoomScale < minimumZoomScale {
             zoomScale /= 2.0
-            
+
             if zoomScale > minimumZoomScale {
                 zoomScale = maximumZoomScale
             }
-            
+
             setZoomScale(zoomScale, animated: true)
         }
     }
-    
+
     open func zoomDecrement() {
         var zoomScale = self.zoomScale
-        
+
         if zoomScale < minimumZoomScale {
             zoomScale *= 2.0
-            
+
             if zoomScale > minimumZoomScale {
                 zoomScale = maximumZoomScale
             }
-            
+
             setZoomScale(zoomScale, animated: true)
         }
     }
-    
+
     open func zoomReset() {
         zoomScale = minimumZoomScale
-        
+
         let offsetX = max((self.bounds.size.width - self.contentSize.width) * 0.5, 0.0)
         let offsetY = max((self.bounds.size.height - self.contentSize.height) * 0.5, 0.0)
-        
+
         containerView.center = CGPoint(x: self.contentSize.width * 0.5 + offsetX,
                                        y: self.contentSize.height * 0.5 + offsetY)
     }
-    
+
     //MARK: - UIScrollViewDelegate methods
     open func viewForZooming(in scrollView: UIScrollView) -> UIView? {
         return containerView
     }
-    
+
     open func scrollViewDidZoom(_ scrollView: UIScrollView) {
         viewDidZoom?(scrollView.zoomScale)
     }
-    
+
     func keyboardWillShowNotification(_ notification: Notification) {
         updateBottomLayoutConstraintWithNotification(notification, show: true)
     }
-    
+
     func keyboardWillHideNotification(_ notification: Notification) {
         updateBottomLayoutConstraintWithNotification(notification, show: false)
     }
-    
+
     func updateBottomLayoutConstraintWithNotification(_ notification: Notification, show:Bool) {
         let userInfo = (notification as NSNotification).userInfo!
-        
+
         let keyboardEndFrame = (userInfo[UIKeyboardFrameEndUserInfoKey] as! NSValue).cgRectValue
         let convertedKeyboardEndFrame = self.convert(keyboardEndFrame, from: self.window)
-        
+
         let height: CGFloat
         if convertedKeyboardEndFrame.height > 0 && show {
             height = convertedKeyboardEndFrame.height + bottomKeyboardPadding
@@ -226,20 +230,20 @@ open class PDFPageContentView: UIScrollView, UIScrollViewDelegate {
 
         contentInset = UIEdgeInsetsMake(0, 0, height, 0)
     }
-    
-    
+
+
     //MARK: - Helper methods
     static func zoomScaleThatFits(_ target: CGSize, source: CGSize) -> CGFloat {
         let widthScale = target.width / source.width
         let heightScale = target.height / source.height
         return (widthScale < heightScale) ? widthScale : heightScale
     }
-    
+
     func updateMinimumMaximumZoom() {
         previousScale = self.zoomScale
         let targetRect = bounds.insetBy(dx: 0, dy: 0)
         let zoomScale = PDFPageContentView.zoomScaleThatFits(targetRect.size, source: contentView.bounds.size)
-        
+
         minimumZoomScale = zoomScale
         maximumZoomScale = zoomScale * 16.0
     }

--- a/Pod/Classes/Renderer/PDFSinglePageViewer.swift
+++ b/Pod/Classes/Renderer/PDFSinglePageViewer.swift
@@ -19,17 +19,17 @@ public protocol PDFSinglePageViewerDelegate {
 }
 
 open class PDFSinglePageViewer: UICollectionView {
-    
+
     open var singlePageDelegate: PDFSinglePageViewerDelegate?
     open var document: PDFDocument?
-    
+
     var internalPage: Int = 0
-    
+
     var scrollDirection: UICollectionViewScrollDirection {
         let flowLayout = collectionViewLayout as! UICollectionViewFlowLayout
         return flowLayout.scrollDirection
     }
-    
+
     private static var flowLayout: UICollectionViewFlowLayout {
         let layout = UICollectionViewFlowLayout()
         layout.scrollDirection = .horizontal
@@ -38,40 +38,40 @@ open class PDFSinglePageViewer: UICollectionView {
         layout.minimumInteritemSpacing = 0.0
         return layout
     }
-    
+
     public init(frame: CGRect, document: PDFDocument) {
         self.document = document
-        
+
         super.init(frame: frame, collectionViewLayout: PDFSinglePageViewer.flowLayout)
-        
+
         setupCollectionView()
     }
-    
+
     required public init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
         collectionViewLayout = PDFSinglePageViewer.flowLayout
-        
+
         setupCollectionView()
     }
-    
+
     func setupCollectionView() {
         isPagingEnabled = true
         backgroundColor = UIColor.groupTableViewBackground
         showsHorizontalScrollIndicator = false
         register(PDFSinglePageCell.self, forCellWithReuseIdentifier: "ContentCell")
-        
+
         delegate = self
         dataSource = self
-        
+
         guard let document = document else { return }
-        
+
         displayPage(document.currentPage, animated: false)
-        
+
         if let pageContentView = getPageContent(document.currentPage) {
             singlePageDelegate?.singlePageViewer(self, loadedContent: pageContentView)
         }
     }
-    
+
     open func indexForPage(_ page: Int) -> Int {
         let currentPage = page - 1
         if currentPage <= 0 {
@@ -82,7 +82,7 @@ open class PDFSinglePageViewer: UICollectionView {
             return currentPage
         }
     }
-    
+
     open func displayPage(_ page: Int, animated: Bool) {
         let currentPage = indexForPage(page)
         let indexPath = IndexPath(item: currentPage, section: 0)
@@ -93,7 +93,7 @@ open class PDFSinglePageViewer: UICollectionView {
             scrollToItem(at: indexPath, at: .top, animated: animated)
         }
     }
-    
+
     open func getPageContent(_ page: Int) -> PDFPageContentView? {
         if document == nil { return nil }
         let currentPage = indexForPage(page)
@@ -103,7 +103,7 @@ open class PDFSinglePageViewer: UICollectionView {
         }
         return nil
     }
-    
+
     open override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
         let result = super.hitTest(point, with: event)
         self.isScrollEnabled = !(result is ResizableBorderView)
@@ -115,25 +115,26 @@ extension PDFSinglePageViewer: UICollectionViewDataSource {
     public func numberOfSections(in collectionView: UICollectionView) -> Int {
         return 1
     }
-    
+
     public func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
         guard let document = self.document else {
             return 0
         }
         return document.pageCount
     }
-    
+
     public func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         let cell = self.dequeueReusableCell(withReuseIdentifier: "ContentCell", for: indexPath) as! PDFSinglePageCell
-        
+
         let contentSize = self.collectionView(collectionView, layout: collectionViewLayout, sizeForItemAt: indexPath)
         let contentFrame = CGRect(origin: CGPoint.zero, size: contentSize)
-        
+
         let page = indexPath.row + 1
 
+        cell.contentView.autoresizingMask = [.flexibleHeight, .flexibleWidth]
         cell.pageContentView = PDFPageContentView(frame: contentFrame, document: document!, page: page)
         cell.pageContentView?.contentDelegate = self
-        
+
         return cell
     }
 }
@@ -157,7 +158,7 @@ extension PDFSinglePageViewer: UICollectionViewDelegateFlowLayout {
         case .vertical:
             let page = indexPath.row + 1
             let contentViewSize = PDFPageContentView(frame: bounds, document: document!, page: page).contentSize
-            
+
             // Find proper aspect ratio so that cell is full width
             let widthMultiplier: CGFloat
             let heightMultiplier: CGFloat
@@ -170,22 +171,22 @@ extension PDFSinglePageViewer: UICollectionViewDelegateFlowLayout {
             } else {
                 fatalError()
             }
-            
+
             return CGSize(width: bounds.size.width * widthMultiplier, height: bounds.size.height * heightMultiplier)
         }
     }
 }
 
 extension PDFSinglePageViewer: UIScrollViewDelegate {
-    
+
     public func scrollViewWillBeginDragging(_ scrollView: UIScrollView) {
         self.singlePageDelegate?.singlePageViewerDidBeginDragging()
     }
-    
+
     public func scrollViewDidEndDragging(_ scrollView: UIScrollView, willDecelerate decelerate: Bool) {
         self.singlePageDelegate?.singlePageViewerDidEndDragging()
     }
-    
+
     public func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
         switch scrollDirection {
         case .horizontal:
@@ -196,11 +197,11 @@ extension PDFSinglePageViewer: UIScrollViewDelegate {
         }
         didDisplayPage(scrollView)
     }
-    
+
     public func scrollViewDidEndScrollingAnimation(_ scrollView: UIScrollView) {
         didDisplayPage(scrollView)
     }
-    
+
     private func didDisplayPage(_ scrollView: UIScrollView) {
         let page: Int
         switch scrollDirection {
@@ -210,14 +211,17 @@ extension PDFSinglePageViewer: UIScrollViewDelegate {
             let currentlyShownIndexPath = indexPathsForVisibleItems.first ?? IndexPath(item: 0, section: 0)
             page = currentlyShownIndexPath.row + 1
         }
-        
+
+        print(page)
+        print(internalPage)
+
         /// If nothing has changed, dont reload
         if page == internalPage {
             return
         }
-        
+
         singlePageDelegate?.singlePageViewer(self, didDisplayPage: page)
-        
+
         let indexPath = IndexPath(row: page - 1, section: 0)
         if let cell = cellForItem(at: indexPath) as? PDFSinglePageCell {
             if let pageContentView = cell.pageContentView {
@@ -235,12 +239,14 @@ extension PDFSinglePageViewer: PDFPageContentViewDelegate {
             displayPage(action.pageIndex, animated: true)
         }
     }
-    
+
     public func contentView(_ contentView: PDFPageContentView, didSelect annotation: PDFAnnotationView) {
         singlePageDelegate?.singlePageViewer(self, selected: annotation)
     }
-    
+
     public func contentView(_ contentView: PDFPageContentView, tapped recognizer: UITapGestureRecognizer) {
         singlePageDelegate?.singlePageViewer(self, tapped: recognizer)
     }
+
+    public func contentView(_ contentView: PDFPageContentView, doubleTapped recognizer: UITapGestureRecognizer) {}
 }


### PR DESCRIPTION
Accepting this PR will:

- Add double tap delegate method in `PDFPageContentViewDelegate`
- Change visibility of `contentView` in `PDFPageContentView`. this allows to refer to the view that contains only the actual pdf content. Very useful if you want to add another layer (of multimedia buttons for example) above the pdf content.