### PR TITLE
Fixed a bug in iOS 9

### DIFF
--- a/Pod/Classes/Renderer/PDFPageContentView.swift
+++ b/Pod/Classes/Renderer/PDFPageContentView.swift
@@ -97,7 +97,7 @@ open class PDFPageContentView: UIScrollView, UIScrollViewDelegate {
         doubleTapRecognizer.numberOfTouchesRequired = 1
         doubleTapRecognizer.numberOfTapsRequired = 2
         doubleTapRecognizer.cancelsTouchesInView = false
-        singleTapRecognizer.require(toFail: singleTapRecognizer)
+        singleTapRecognizer.require(toFail: doubleTapRecognizer)
         self.addGestureRecognizer(doubleTapRecognizer)
     }
 


### PR DESCRIPTION
This patch fix  that deinit of `PDFPageContentView` fail in iOS 9 by wrong configuration of gesture recognizers.