### PR TITLE
Fix crash when setting 'showsScrubber' before view has loaded

### DIFF
--- a/Pod/Classes/Renderer/PDFViewController.swift
+++ b/Pod/Classes/Renderer/PDFViewController.swift
@@ -17,6 +17,9 @@ open class PDFViewController: UIViewController {
     /// A boolean value that determines if the scrubber bar should be visible
     open var showsScrubber: Bool = true {
         didSet {
+            guard isViewLoaded else {
+                return
+            }
             pageScrubber.isHidden = !showsScrubber
         }
     }


### PR DESCRIPTION
This was crashing for me when I was setting this value before pushing the view controller. This was because the view was not loaded, and `pageScrubber` is created in `viewDidLoad()`, so in the didSet we were attempting to access a nil value.

<img width="1343" alt="screen shot 2017-06-27 at 6 50 14 pm" src="https://user-images.githubusercontent.com/327737/27617356-9fa59e90-5b6a-11e7-816b-352c3f60a5d7.png">
<img width="1333" alt="screen shot 2017-06-27 at 6 50 25 pm" src="https://user-images.githubusercontent.com/327737/27617362-a35b5872-5b6a-11e7-9abf-e661c1869eae.png">
